### PR TITLE
Format logic expressions better

### DIFF
--- a/app/Region/Inverted/DarkWorld/DeathMountain/East.php
+++ b/app/Region/Inverted/DarkWorld/DeathMountain/East.php
@@ -22,9 +22,9 @@ class East extends Region\Standard\DarkWorld\DeathMountain\East
                 && ($items->canLiftRocks()
                     || ($items->has('MagicMirror')
                         && $items->canBombThings()
-                        && $this->world->getRegion('East Death Mountain')->canEnter($locations, $items)) || ($this->world->config('canBootsClip', false)
-                        && $items->has('PegasusBoots')) ||
-                    $this->world->config('canOneFrameClipOW', false));
+                        && $this->world->getRegion('East Death Mountain')->canEnter($locations, $items))
+                    || ($this->world->config('canBootsClip', false) && $items->has('PegasusBoots'))
+                    || $this->world->config('canOneFrameClipOW', false));
         });
 
         $this->locations["Hookshot Cave - Top Left"]->setRequirements(function ($locations, $items) {
@@ -32,9 +32,9 @@ class East extends Region\Standard\DarkWorld\DeathMountain\East
                 && ($items->canLiftRocks()
                     || ($items->has('MagicMirror')
                         && $items->canBombThings()
-                        && $this->world->getRegion('East Death Mountain')->canEnter($locations, $items)) || ($this->world->config('canBootsClip', false)
-                        && $items->has('PegasusBoots')) ||
-                    $this->world->config('canOneFrameClipOW', false));
+                        && $this->world->getRegion('East Death Mountain')->canEnter($locations, $items))
+                    || ($this->world->config('canBootsClip', false) && $items->has('PegasusBoots'))
+                    || $this->world->config('canOneFrameClipOW', false));
         });
 
         $this->locations["Hookshot Cave - Bottom Left"]->setRequirements(function ($locations, $items) {
@@ -42,9 +42,9 @@ class East extends Region\Standard\DarkWorld\DeathMountain\East
                 && ($items->canLiftRocks()
                     || ($items->has('MagicMirror')
                         && $items->canBombThings()
-                        && $this->world->getRegion('East Death Mountain')->canEnter($locations, $items)) || ($this->world->config('canBootsClip', false)
-                        && $items->has('PegasusBoots')) ||
-                    $this->world->config('canOneFrameClipOW', false));
+                        && $this->world->getRegion('East Death Mountain')->canEnter($locations, $items))
+                    || ($this->world->config('canBootsClip', false) && $items->has('PegasusBoots'))
+                    || $this->world->config('canOneFrameClipOW', false));
         });
 
         $this->locations["Hookshot Cave - Bottom Right"]->setRequirements(function ($locations, $items) {
@@ -52,22 +52,22 @@ class East extends Region\Standard\DarkWorld\DeathMountain\East
                 || $items->has('PegasusBoots')) && ($items->canLiftRocks()
                 || ($items->has('MagicMirror')
                     && $items->canBombThings()
-                    && $this->world->getRegion('East Death Mountain')->canEnter($locations, $items)) || ($this->world->config('canBootsClip', false)
-                    && $items->has('PegasusBoots')) ||
-                $this->world->config('canOneFrameClipOW', false));
+                    && $this->world->getRegion('East Death Mountain')->canEnter($locations, $items))
+                || ($this->world->config('canBootsClip', false) && $items->has('PegasusBoots'))
+                || $this->world->config('canOneFrameClipOW', false));
         });
 
         $this->can_enter = function ($locations, $items) {
             return ($this->world->getRegion('West Dark World Death Mountain')->canEnter($locations, $items)
-                && (!$this->world->config('region.cantTakeDamage', false)
-                    || $items->has('CaneOfByrna')
-                    || $items->has('Cape')
-                    || ($this->world->config('canBootsClip', false)
-                        && $items->has('PegasusBoots')) ||
-                    $this->world->config('canOneFrameClipOW', false))) || ($items->has('MagicMirror')
-                && $items->has('MoonPearl')
-                && $items->has('Hookshot')
-                && $this->world->getRegion('West Death Mountain')->canEnter($locations, $items));
+                    && (!$this->world->config('region.cantTakeDamage', false)
+                        || $items->has('CaneOfByrna')
+                        || $items->has('Cape')
+                        || ($this->world->config('canBootsClip', false) && $items->has('PegasusBoots'))
+                        || $this->world->config('canOneFrameClipOW', false)))
+                || ($items->has('MagicMirror')
+                    && $items->has('MoonPearl')
+                    && $items->has('Hookshot')
+                    && $this->world->getRegion('West Death Mountain')->canEnter($locations, $items));
         };
 
         return $this;

--- a/app/Region/Inverted/DarkWorld/DeathMountain/West.php
+++ b/app/Region/Inverted/DarkWorld/DeathMountain/West.php
@@ -35,21 +35,17 @@ class West extends Region\Standard\DarkWorld\DeathMountain\West
         $this->locations["Spike Cave"]->setRequirements(function ($locations, $items) {
             return $items->has('Hammer')
                 && $items->canLiftRocks()
-                && (
-                    ($items->canExtendMagic()
-                        && $items->has('Cape')) || (
-                        (!$this->world->config('region.cantTakeDamage', false)
-                            || $items->canExtendMagic()) &&
-                        $items->has('CaneOfByrna')));
+                && (($items->canExtendMagic() && $items->has('Cape'))
+                    || ((!$this->world->config('region.cantTakeDamage', false) || $items->canExtendMagic())
+                        && $items->has('CaneOfByrna')));
         });
 
         $this->can_enter = function ($locations, $items) {
             return $items->canFly($this->world)
-                || ($items->canLiftRocks()
-                    && $items->has('Lamp', $this->world->config('item.require.Lamp', 1))) || ($this->world->config('canBootsClip', false)
-                    && $items->has('PegasusBoots')) || ($this->world->config('canOWYBA', false)
-                    && $items->hasABottle()) ||
-                $this->world->config('canOneFrameClipOW', false);
+                || ($items->canLiftRocks() && $items->has('Lamp', $this->world->config('item.require.Lamp', 1)))
+                || ($this->world->config('canBootsClip', false) && $items->has('PegasusBoots'))
+                || ($this->world->config('canOWYBA', false) && $items->hasABottle())
+                || $this->world->config('canOneFrameClipOW', false);
         };
 
         return $this;

--- a/app/Region/Inverted/DarkWorld/Mire.php
+++ b/app/Region/Inverted/DarkWorld/Mire.php
@@ -20,10 +20,10 @@ class Mire extends Region\Standard\DarkWorld\Mire
         $this->can_enter = function ($locations, $items) {
             return $items->canFly($this->world)
                 || ($items->has('MagicMirror')
-                    && $this->world->getRegion('South Light World')->canEnter($locations, $items)) || ($this->world->config('canBootsClip', false)
-                    && $items->has('PegasusBoots')) || ($this->world->config('canOWYBA', false)
-                    && $items->hasABottle()) ||
-                $this->world->config('canOneFrameClipOW', false);
+                    && $this->world->getRegion('South Light World')->canEnter($locations, $items))
+                || ($this->world->config('canBootsClip', false) && $items->has('PegasusBoots'))
+                || ($this->world->config('canOWYBA', false) && $items->hasABottle())
+                || $this->world->config('canOneFrameClipOW', false);
         };
 
         return $this;

--- a/app/Region/Inverted/DarkWorld/NorthEast.php
+++ b/app/Region/Inverted/DarkWorld/NorthEast.php
@@ -38,22 +38,22 @@ class NorthEast extends Region\Standard\DarkWorld\NorthEast
                 || $items->has('Flippers')
                 || ($items->has('MagicMirror')
                     && $this->world->getRegion('North East Light World')->canEnter($locations, $items)
-                    && $items->has('MoonPearl')) || ($this->world->config('canOWYBA', false)
-                    && $items->hasABottle()) || ($this->world->config('canBootsClip', false)
-                    && $items->has('PegasusBoots')) || ($this->world->config('canSuperSpeed', false)
-                    && $items->canSpinSpeed()) || ($this->world->config('canOneFrameClipOW', false)
-                    || ( //Quirn-Jump
+                    && $items->has('MoonPearl'))
+                || ($this->world->config('canOWYBA', false) && $items->hasABottle())
+                || ($this->world->config('canBootsClip', false) && $items->has('PegasusBoots'))
+                || ($this->world->config('canSuperSpeed', false) && $items->canSpinSpeed())
+                || ($this->world->config('canOneFrameClipOW', false)
+                    || ( // Quirn-Jump
                         !$this->world->config('region.cantTakeDamage', false)
-                        && $this->world->config('canFakeFlipper', false)) || ($this->world->config('canBunnyRevive', false)
-                        && $items->canBunnyRevive())) || ($this->world->config('canWaterWalk', false)
-                    && $items->has('PegasusBoots'));
+                        && $this->world->config('canFakeFlipper', false))
+                    || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive()))
+                || ($this->world->config('canWaterWalk', false) && $items->has('PegasusBoots'));
         });
 
         $this->locations["Catfish"]->setRequirements(function ($locations, $items) {
             return $items->canLiftRocks()
-                || ($this->world->config('canBootsClip', false)
-                    && $items->has('PegasusBoots')) ||
-                $this->world->config('canOneFrameClipOW', false);
+                || ($this->world->config('canBootsClip', false) && $items->has('PegasusBoots'))
+                || $this->world->config('canOneFrameClipOW', false);
         });
 
         $this->locations["Pyramid Fairy - Sword"]->setRequirements(function ($locations, $items) {
@@ -86,14 +86,15 @@ class NorthEast extends Region\Standard\DarkWorld\NorthEast
                 || $items->has('Hammer')
                 || $items->has('Flippers')
                 || ($items->has('MagicMirror')
-                    && $this->world->getRegion('North East Light World')->canEnter($locations, $items)) || ($this->world->config('canOWYBA', false)
-                    && $items->hasABottle()) || ($this->world->config('canBootsClip', false)
-                    && $items->has('PegasusBoots')) || ($this->world->config('canWaterWalk', false)
-                    && $items->has('PegasusBoots')) || ($this->world->config('canSuperSpeed', false)
-                    && $items->canSpinSpeed()) || (!$this->world->config('region.cantTakeDamage', false)
-                    && $this->world->config('canFakeFlipper', false)) || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive()) ||
-                $this->world->config('canOneFrameClipOW', false);
+                    && $this->world->getRegion('North East Light World')->canEnter($locations, $items))
+                || ($this->world->config('canOWYBA', false) && $items->hasABottle())
+                || ($this->world->config('canBootsClip', false) && $items->has('PegasusBoots'))
+                || ($this->world->config('canWaterWalk', false) && $items->has('PegasusBoots'))
+                || ($this->world->config('canSuperSpeed', false) && $items->canSpinSpeed())
+                || (!$this->world->config('region.cantTakeDamage', false)
+                    && $this->world->config('canFakeFlipper', false))
+                || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
+                || $this->world->config('canOneFrameClipOW', false);
         };
 
         return $this;

--- a/app/Region/Inverted/DarkWorld/NorthWest.php
+++ b/app/Region/Inverted/DarkWorld/NorthWest.php
@@ -30,48 +30,39 @@ class NorthWest extends Region\Standard\DarkWorld\NorthWest
                 && ($items->canLiftDarkRocks()
                     || ($items->has('MagicMirror')
                         && $this->world->getRegion('North West Light World')->canEnter($locations, $items))
-                    || ($this->world->config('canBootsClip', false)
-                        && $items->has('PegasusBoots')) || (
-                        ($this->world->config('canFakeFlipper', false)
-                            || $items->has('Flippers')
-                            && (($this->world->config('canSuperSpeed', false)
-                                && $items->canSpinSpeed())
-                                || $this->world->config('canOneFrameClipOW', false)))));
+                    || ($this->world->config('canBootsClip', false) && $items->has('PegasusBoots'))
+                    || (($this->world->config('canFakeFlipper', false) || $items->has('Flippers')
+                        && (($this->world->config('canSuperSpeed', false) && $items->canSpinSpeed())
+                            || $this->world->config('canOneFrameClipOW', false)))));
         });
 
         $this->locations["Bumper Cave"]->setRequirements(function ($locations, $items) {
             return ($items->canLiftRocks()
-                && $items->has('Cape')
-                && $items->has('MoonPearl')
-                && $items->has('MagicMirror')
-                && $this->world->getRegion('North West Light World')->canEnter($locations, $items))
-                || ($this->world->config('canBootsClip', false)
-                    && $items->has('PegasusBoots'))
+                    && $items->has('Cape')
+                    && $items->has('MoonPearl')
+                    && $items->has('MagicMirror')
+                    && $this->world->getRegion('North West Light World')->canEnter($locations, $items))
+                || ($this->world->config('canBootsClip', false) && $items->has('PegasusBoots'))
                 || $this->world->config('canOneFrameClipOW', false);
         });
 
         $this->locations["Blacksmith"]->setRequirements(function ($locations, $items) {
             return ($items->canLiftDarkRocks()
-                || ($items->has('MagicMirror')
-                || (
-                    ($this->world->config('canOWYBA', false)
-                        && $items->hasABottle()) && ($this->world->config('canOneFrameClipOW', false)
-                        || ($this->world->config('canBootsClip', false)
-                            && $items->has('PegasusBoots'))))))
+                    || ($items->has('MagicMirror')
+                    || (($this->world->config('canOWYBA', false) && $items->hasABottle())
+                        && ($this->world->config('canOneFrameClipOW', false)
+                            || ($this->world->config('canBootsClip', false) && $items->has('PegasusBoots'))))))
                 && $this->world->getRegion('North West Light World')->canEnter($locations, $items);
         });
 
         $this->locations["Purple Chest"]->setRequirements(function ($locations, $items) {
             return ($items->canLiftDarkRocks()
-                || ($items->has('MagicMirror')
-                || (($this->world->config('canOWYBA', false)
-                    && $items->hasABottle())
-                    && (($this->world->config('canFakeFlipper', false)
-                        || $items->has('Flippers'))
-                        && (($this->world->config('canBootsClip', false)
-                            && $items->has('PegasusBoots'))
-                            || $this->world->config('canOneFrameClipOW', false))))
-                && $this->world->getRegion('North West Light World')->canEnter($locations, $items)))
+                    || ($items->has('MagicMirror')
+                    || (($this->world->config('canOWYBA', false) && $items->hasABottle())
+                        && (($this->world->config('canFakeFlipper', false) || $items->has('Flippers'))
+                            && (($this->world->config('canBootsClip', false) && $items->has('PegasusBoots'))
+                                || $this->world->config('canOneFrameClipOW', false))))
+                    && $this->world->getRegion('North West Light World')->canEnter($locations, $items)))
                 && $this->world->getRegion('South Light World')->canEnter($locations, $items);
         });
 

--- a/app/Region/Inverted/DarkWorld/South.php
+++ b/app/Region/Inverted/DarkWorld/South.php
@@ -47,19 +47,14 @@ class South extends Region\Standard\DarkWorld\South
             return $items->canBombThings()
                 && ($items->has('Flippers')
                     || $items->canFly($this->world)
-                    || ($this->world->config('canOWYBA', false)
-                        && $items->hasABottle()) || (
-                        ($this->world->config('canBootsClip', false)
-                            || $this->world->config('canWaterWalk', false))
-                        && $items->has('PegasusBoots')) ||
-                    $this->world->config('canOneFrameClipOW', false)
+                    || ($this->world->config('canOWYBA', false) && $items->hasABottle())
+                    || (($this->world->config('canBootsClip', false) || $this->world->config('canWaterWalk', false))
+                            && $items->has('PegasusBoots'))
+                    || $this->world->config('canOneFrameClipOW', false)
                     || ($this->world->config('canFakeFlipper', false)
-                        && (
-                            ($this->world->getRegion('North East Dark World')->canEnter($locations, $items)
-                                && ($items->has('Hammer')
-                                    || $items->canLiftRocks()))
-                            || ($this->World->config('canBunnyRevive', false)
-                                && $items->canBunnyRevive()))
+                        && (($this->world->getRegion('North East Dark World')->canEnter($locations, $items)
+                                && ($items->has('Hammer') || $items->canLiftRocks()))
+                            || ($this->World->config('canBunnyRevive', false) && $items->canBunnyRevive()))
                         || ($this->world->getRegion('North West Dark World')->canEnter($locations, $items)
                             && $this->world->config('region.cantTakeDamage', false))));
         });
@@ -68,19 +63,14 @@ class South extends Region\Standard\DarkWorld\South
             return $items->canLiftRocks()
                 && ($items->has('Flippers')
                     || $items->canFly($this->world)
-                    || ($this->world->config('canOWYBA', false)
-                        && $items->hasABottle()) || (
-                        ($this->world->config('canBootsClip', false)
-                            || $this->world->config('canWaterWalk', false))
-                        && $items->has('PegasusBoots')) ||
-                    $this->world->config('canOneFrameClipOW', false)
+                    || ($this->world->config('canOWYBA', false) && $items->hasABottle())
+                    || (($this->world->config('canBootsClip', false) || $this->world->config('canWaterWalk', false))
+                            && $items->has('PegasusBoots'))
+                    || $this->world->config('canOneFrameClipOW', false)
                     || ($this->world->config('canFakeFlipper', false)
-                        && (
-                            ($this->world->getRegion('North East Dark World')->canEnter($locations, $items)
-                                && ($items->has('Hammer')
-                                    || $items->canLiftRocks()))
-                            || ($this->World->config('canBunnyRevive', false)
-                                && $items->canBunnyRevive()))
+                        && (($this->world->getRegion('North East Dark World')->canEnter($locations, $items)
+                                && ($items->has('Hammer') || $items->canLiftRocks()))
+                            || ($this->World->config('canBunnyRevive', false) && $items->canBunnyRevive()))
                         || ($this->world->getRegion('North West Dark World')->canEnter($locations, $items)
                             && $this->world->config('region.cantTakeDamage', false))));
         });
@@ -89,18 +79,14 @@ class South extends Region\Standard\DarkWorld\South
             return $items->canLiftRocks()
                 && ($items->has('Flippers')
                     || $items->canFly($this->world)
-                    || ($this->world->config('canOWYBA', false)
-                        && $items->hasABottle()) || (
-                        ($this->world->config('canBootsClip', false)
-                            || $this->world->config('canWaterWalk', false))
-                        && $items->has('PegasusBoots')) ||
-                    $this->world->config('canOneFrameClipOW', false)
+                    || ($this->world->config('canOWYBA', false) && $items->hasABottle())
+                    || (($this->world->config('canBootsClip', false) || $this->world->config('canWaterWalk', false))
+                            && $items->has('PegasusBoots'))
+                    || $this->world->config('canOneFrameClipOW', false)
                     || ($this->world->config('canFakeFlipper', false)
-                        && (
-                            ($this->world->getRegion('North East Dark World')->canEnter($locations, $items)
-                                && ($items->has('Hammer')
-                                    || $items->canLiftRocks())) || ($this->World->config('canBunnyRevive', false)
-                                && $items->canBunnyRevive()))
+                        && (($this->world->getRegion('North East Dark World')->canEnter($locations, $items)
+                                && ($items->has('Hammer') || $items->canLiftRocks()))
+                            || ($this->World->config('canBunnyRevive', false) && $items->canBunnyRevive()))
                         || ($this->world->getRegion('North West Dark World')->canEnter($locations, $items)
                             && $this->world->config('region.cantTakeDamage', false))));
         });

--- a/app/Region/Inverted/DesertPalace.php
+++ b/app/Region/Inverted/DesertPalace.php
@@ -27,14 +27,11 @@ class DesertPalace extends Region\Standard\DesertPalace
 
         $side = function ($locations, $items) {
             return $this->world->config('canOneFrameClipOW', false)
-                || (
-                    ($items->has('MoonPearl')
-                        || ($this->world->config('canOWYBA', false)
-                            && $items->hasABottle()) || ($this->world->config('canBunnyRevive', false)
-                            && $items->canBunnyRevive())) && (
-                        ($this->world->config('canBootsClip', false)
-                            && $items->has('PegasusBoots')))) &&
-                $this->world->getRegion('South Light World')->canEnter($locations, $items);
+                || (($items->has('MoonPearl')
+                        || ($this->world->config('canOWYBA', false) && $items->hasABottle())
+                        || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive()))
+                    && (($this->world->config('canBootsClip', false) && $items->has('PegasusBoots'))))
+                && $this->world->getRegion('South Light World')->canEnter($locations, $items);
         };
 
         $thieves = function ($locations, $items) {
@@ -45,49 +42,46 @@ class DesertPalace extends Region\Standard\DesertPalace
         };
 
 
-
         $this->locations["Desert Palace - Big Key Chest"]->setRequirements(function ($locations, $items) {
             return $items->has('KeyP2')
                 && ($items->has('MoonPearl')
                     || $this->world->config('canDungeonRevive', false)
-                    || ($this->world->config('canBunnyRevive', false)
-                        && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
-                        && $items->hasABottle()) || $items->hasSword());
+                    || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
+                    || ($this->world->config('canOWYBA', false) && $items->hasABottle())
+                    || $items->hasSword());
         });
 
 
         $this->locations["Desert Palace - Boss"]->setRequirements(function ($locations, $items) {
             return $this->canEnter($locations, $items)
-                && (
-                    ($items->has('MoonPearl')
-                        || ($this->world->config('canBunnyRevive', false)
-                            && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
-                            && $items->hasABottle())) || ($this->world->config('canOneFrameClipOW', false)
+                && (($items->has('MoonPearl')
+                        || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
+                        || ($this->world->config('canOWYBA', false) && $items->hasABottle()))
+                    || ($this->world->config('canOneFrameClipOW', false)
                         && $this->world->config('canDungeonRevive', false)))
-                && ($items->canLiftRocks() || ($this->world->config('canBootsClip', false)
-                    && $items->has('PegasusBoots')) || $this->world->config('canOneFrameClipOW', false))
+                && ($items->canLiftRocks()
+                    || ($this->world->config('canBootsClip', false) && $items->has('PegasusBoots'))
+                    || $this->world->config('canOneFrameClipOW', false))
                 && $items->canLightTorches()
                 && $items->has('BigKeyP2')
                 && $items->has('KeyP2')
                 && $this->boss->canBeat($items, $locations)
-                && (!$this->world->config('region.wildCompasses', false)
-                    || $items->has('CompassP2')
+                && (!$this->world->config('region.wildCompasses', false) || $items->has('CompassP2')
                     || $this->locations["Desert Palace - Boss"]->hasItem(Item::get('CompassP2', $this->world)))
-                && (!$this->world->config('region.wildMaps', false)
-                    || $items->has('MapP2')
+                && (!$this->world->config('region.wildMaps', false) || $items->has('MapP2')
                     || $this->locations["Desert Palace - Boss"]->hasItem(Item::get('MapP2', $this->world)));
         });
 
         // Bunny can use Book!
         $this->can_enter = function ($locations, $items) use ($main, $side, $thieves) {
             return ($this->world->config('canDungeonRevive', false)
-                || ($this->world->config('canSuperBunny', false)
-                    && $items->has('MagicMirror')) || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
-                    && $items->hasABottle()) ||
-                $items->has('MoonPearl')) && ($main($locations, $items)
-                || $side($locations, $items)
-                || $thieves($locations, $items));
+                    || ($this->world->config('canSuperBunny', false) && $items->has('MagicMirror'))
+                    || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
+                    || ($this->world->config('canOWYBA', false) && $items->hasABottle())
+                    || $items->has('MoonPearl'))
+                && ($main($locations, $items)
+                    || $side($locations, $items)
+                    || $thieves($locations, $items));
         };
 
         return $this;

--- a/app/Region/Inverted/EasternPalace.php
+++ b/app/Region/Inverted/EasternPalace.php
@@ -23,57 +23,52 @@ class EasternPalace extends Region\Standard\EasternPalace
         $this->locations["Eastern Palace - Compass Chest"]->setRequirements(function ($locations, $items) {
             return $items->hasSword()
                 || $this->world->config('canDungeonRevive', false)
-                || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
-                    && $items->hasABottle()) ||
-                $items->has('MoonPearl');
+                || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
+                || ($this->world->config('canOWYBA', false) && $items->hasABottle())
+                || $items->has('MoonPearl');
         });
 
         $this->locations["Eastern Palace - Big Chest"]->setRequirements(function ($locations, $items) {
             return ($items->hasSword()
-                || $this->world->config('canDungeonRevive', false)
-                || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
-                    && $items->hasABottle()) ||
-                $items->has('MoonPearl')) &&
-                $items->has('BigKeyP1');
+                    || $this->world->config('canDungeonRevive', false)
+                    || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
+                    || ($this->world->config('canOWYBA', false) && $items->hasABottle())
+                    || $items->has('MoonPearl'))
+                && $items->has('BigKeyP1');
         });
 
         $this->locations["Eastern Palace - Big Key Chest"]->setRequirements(function ($locations, $items) {
             return ($items->hasSword()
-                ||
-                $this->world->config('canDungeonRevive', false)
-                || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
-                    && $items->hasABottle()) ||
-                $items->has('MoonPearl')) && $items->has('Lamp', $this->world->config('item.require.Lamp', 1));
+                    || $this->world->config('canDungeonRevive', false)
+                    || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
+                    || ($this->world->config('canOWYBA', false) && $items->hasABottle())
+                    || $items->has('MoonPearl'))
+                && $items->has('Lamp', $this->world->config('item.require.Lamp', 1));
         });
 
         $this->locations["Eastern Palace - Boss"]->setRequirements(function ($locations, $items) {
             return $items->canShootArrows($this->world)
                 && ($this->world->config('canDungeonRevive', false)
-                    || ($this->world->config('canBunnyRevive', false)
-                        && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
-                        && $items->hasABottle()) ||
-                    $items->has('MoonPearl')) && ($items->has('Lamp', $this->world->config('item.require.Lamp', 1))
-                    || ($this->world->config('itemPlacement') === 'advanced'
-                        && $items->has('FireRod'))) && $items->has('BigKeyP1')
+                    || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
+                    || ($this->world->config('canOWYBA', false) && $items->hasABottle())
+                    || $items->has('MoonPearl'))
+                && ($items->has('Lamp', $this->world->config('item.require.Lamp', 1))
+                    || ($this->world->config('itemPlacement') === 'advanced' && $items->has('FireRod')))
+                && $items->has('BigKeyP1')
                 && $this->boss->canBeat($items, $locations)
-                && (!$this->world->config('region.wildCompasses', false)
-                    || $items->has('CompassP1')
-                    || $this->locations["Eastern Palace - Boss"]->hasItem(Item::get('CompassP1', $this->world))) && (!$this->world->config('region.wildMaps', false)
-                    || $items->has('MapP1')
+                && (!$this->world->config('region.wildCompasses', false) || $items->has('CompassP1')
+                    || $this->locations["Eastern Palace - Boss"]->hasItem(Item::get('CompassP1', $this->world)))
+                && (!$this->world->config('region.wildMaps', false) || $items->has('MapP1')
                     || $this->locations["Eastern Palace - Boss"]->hasItem(Item::get('MapP1', $this->world)));
         });
 
         $this->can_enter = function ($locations, $items) {
             return ($this->world->config('canDungeonRevive', false)
-                || ($this->world->config('canSuperBunny', false)
-                    && $items->has('MagicMirror')) || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
-                    && $items->hasABottle()) ||
-                $items->has('MoonPearl')) &&
-                $this->world->getRegion('North East Light World')->canEnter($locations, $items);
+                    || ($this->world->config('canSuperBunny', false) && $items->has('MagicMirror'))
+                    || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
+                    || ($this->world->config('canOWYBA', false) && $items->hasABottle())
+                    || $items->has('MoonPearl'))
+                && $this->world->getRegion('North East Light World')->canEnter($locations, $items);
         };
 
         return $this;

--- a/app/Region/Inverted/GanonsTower.php
+++ b/app/Region/Inverted/GanonsTower.php
@@ -21,363 +21,284 @@ class GanonsTower extends Region\Standard\GanonsTower
         parent::initalize();
 
         $this->locations["Ganon's Tower - DMs Room - Top Left"]->setRequirements(function ($locations, $items) {
-            return $items->has('Hammer')
-                && $items->has('Hookshot')
-                && ($items->has('MoonPearl') || $this->world->config('canDungeonRevive', false)
-                    || (
-                        ($this->world->config('canOneFrameClipOW', false)
-                            || ($this->world->config('canBootsClip', false)
-                                && $items->has('PegasusBoots'))) && (
-                            ($this->world->config('canBunnyRevive', false)
-                                && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
-                                && $items->hasABottle()))));
+            return $items->has('Hammer') && $items->has('Hookshot')
+                && ($items->has('MoonPearl')
+                    || $this->world->config('canDungeonRevive', false)
+                    || (($this->world->config('canOneFrameClipOW', false)
+                            || ($this->world->config('canBootsClip', false) && $items->has('PegasusBoots')))
+                        && (($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
+                            || ($this->world->config('canOWYBA', false) && $items->hasABottle()))));
         });
 
         $this->locations["Ganon's Tower - DMs Room - Top Right"]->setRequirements(function ($locations, $items) {
-            return $items->has('Hammer')
-                && $items->has('Hookshot')
-                && ($items->has('MoonPearl') || $this->world->config('canDungeonRevive', false)
-                    || (
-                        ($this->world->config('canOneFrameClipOW', false)
-                            || ($this->world->config('canBootsClip', false)
-                                && $items->has('PegasusBoots'))) && (
-                            ($this->world->config('canBunnyRevive', false)
-                                && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
-                                && $items->hasABottle()))));
+            return $items->has('Hammer') && $items->has('Hookshot')
+                && ($items->has('MoonPearl')
+                    || $this->world->config('canDungeonRevive', false)
+                    || (($this->world->config('canOneFrameClipOW', false)
+                            || ($this->world->config('canBootsClip', false) && $items->has('PegasusBoots')))
+                        && (($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
+                            || ($this->world->config('canOWYBA', false) && $items->hasABottle()))));
         });
 
         $this->locations["Ganon's Tower - DMs Room - Bottom Left"]->setRequirements(function ($locations, $items) {
-            return $items->has('Hammer')
-                && $items->has('Hookshot')
-                && ($items->has('MoonPearl') || $this->world->config('canDungeonRevive', false)
-                    || (
-                        ($this->world->config('canOneFrameClipOW', false)
-                            || ($this->world->config('canBootsClip', false)
-                                && $items->has('PegasusBoots'))) && (
-                            ($this->world->config('canBunnyRevive', false)
-                                && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
-                                && $items->hasABottle()))));
+            return $items->has('Hammer') && $items->has('Hookshot')
+                && ($items->has('MoonPearl')
+                    || $this->world->config('canDungeonRevive', false)
+                    || (($this->world->config('canOneFrameClipOW', false)
+                            || ($this->world->config('canBootsClip', false) && $items->has('PegasusBoots')))
+                        && (($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
+                            || ($this->world->config('canOWYBA', false) && $items->hasABottle()))));
         });
 
         $this->locations["Ganon's Tower - DMs Room - Bottom Right"]->setRequirements(function ($locations, $items) {
-            return $items->has('Hammer')
-                && $items->has('Hookshot')
-                && ($items->has('MoonPearl') || $this->world->config('canDungeonRevive', false)
-                    || (
-                        ($this->world->config('canOneFrameClipOW', false)
-                            || ($this->world->config('canBootsClip', false)
-                                && $items->has('PegasusBoots'))) && (
-                            ($this->world->config('canBunnyRevive', false)
-                                && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
-                                && $items->hasABottle()))));
+            return $items->has('Hammer') && $items->has('Hookshot')
+                && ($items->has('MoonPearl')
+                    || $this->world->config('canDungeonRevive', false)
+                    || (($this->world->config('canOneFrameClipOW', false)
+                            || ($this->world->config('canBootsClip', false) && $items->has('PegasusBoots')))
+                        && (($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
+                            || ($this->world->config('canOWYBA', false) && $items->hasABottle()))));
         });
 
         $this->locations["Ganon's Tower - Randomizer Room - Top Left"]->setRequirements(function ($locations, $items) {
-            return $items->has('Hammer')
-                && $items->has('Hookshot')
-                && (
-                    ($locations->itemInLocations(Item::get('BigKeyA2', $this->world), [
+            return $items->has('Hammer') && $items->has('Hookshot')
+                && (($locations->itemInLocations(Item::get('BigKeyA2', $this->world), [
                         "Ganon's Tower - Randomizer Room - Top Right",
                         "Ganon's Tower - Randomizer Room - Bottom Left",
                         "Ganon's Tower - Randomizer Room - Bottom Right",
-                    ])
-                        && $items->has('KeyA2', 3)) ||
-                    $items->has('KeyA2', 4)) && ($items->has('MoonPearl')
+                    ]) && $items->has('KeyA2', 3))
+                        || $items->has('KeyA2', 4))
+                && ($items->has('MoonPearl')
                     || $this->world->config('canDungeonRevive', false)
-                    || (
-                        ($this->world->config('canOneFrameClipOW', false)
-                            || ($this->world->config('canBootsClip', false)
-                                && $items->has('PegasusBoots'))) && (
-                            ($this->world->config('canBunnyRevive', false)
-                                && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
-                                && $items->hasABottle()))));
+                    || (($this->world->config('canOneFrameClipOW', false)
+                            || ($this->world->config('canBootsClip', false) && $items->has('PegasusBoots')))
+                        && (($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
+                            || ($this->world->config('canOWYBA', false) && $items->hasABottle()))));
         });
 
         $this->locations["Ganon's Tower - Randomizer Room - Top Right"]->setRequirements(function ($locations, $items) {
-            return $items->has('Hammer')
-                && $items->has('Hookshot')
-                && (
-                    ($locations->itemInLocations(Item::get('BigKeyA2', $this->world), [
+            return $items->has('Hammer') && $items->has('Hookshot')
+                && (($locations->itemInLocations(Item::get('BigKeyA2', $this->world), [
                         "Ganon's Tower - Randomizer Room - Top Left",
                         "Ganon's Tower - Randomizer Room - Bottom Left",
                         "Ganon's Tower - Randomizer Room - Bottom Right",
-                    ])
-                        && $items->has('KeyA2', 3)) ||
-                    $items->has('KeyA2', 4)) && ($items->has('MoonPearl')
+                    ]) && $items->has('KeyA2', 3))
+                        || $items->has('KeyA2', 4))
+                && ($items->has('MoonPearl')
                     || $this->world->config('canDungeonRevive', false)
-                    || (
-                        ($this->world->config('canOneFrameClipOW', false)
-                            || ($this->world->config('canBootsClip', false)
-                                && $items->has('PegasusBoots'))) && (
-                            ($this->world->config('canBunnyRevive', false)
-                                && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
-                                && $items->hasABottle()))));
+                    || (($this->world->config('canOneFrameClipOW', false)
+                            || ($this->world->config('canBootsClip', false) && $items->has('PegasusBoots')))
+                        && (($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
+                            || ($this->world->config('canOWYBA', false) && $items->hasABottle()))));
         });
 
         $this->locations["Ganon's Tower - Randomizer Room - Bottom Left"]->setRequirements(function ($locations, $items) {
-            return $items->has('Hammer')
-                && $items->has('Hookshot')
-                && (
-                    ($locations->itemInLocations(Item::get('BigKeyA2', $this->world), [
+            return $items->has('Hammer') && $items->has('Hookshot')
+                && (($locations->itemInLocations(Item::get('BigKeyA2', $this->world), [
                         "Ganon's Tower - Randomizer Room - Top Right",
                         "Ganon's Tower - Randomizer Room - Top Left",
                         "Ganon's Tower - Randomizer Room - Bottom Right",
-                    ])
-                        && $items->has('KeyA2', 3)) ||
-                    $items->has('KeyA2', 4)) && ($items->has('MoonPearl')
+                    ]) && $items->has('KeyA2', 3))
+                        || $items->has('KeyA2', 4))
+                && ($items->has('MoonPearl')
                     || $this->world->config('canDungeonRevive', false)
-                    || (
-                        ($this->world->config('canOneFrameClipOW', false)
-                            || ($this->world->config('canBootsClip', false)
-                                && $items->has('PegasusBoots'))) && (
-                            ($this->world->config('canBunnyRevive', false)
-                                && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
-                                && $items->hasABottle()))));
+                    || (($this->world->config('canOneFrameClipOW', false)
+                            || ($this->world->config('canBootsClip', false) && $items->has('PegasusBoots')))
+                        && (($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
+                            || ($this->world->config('canOWYBA', false) && $items->hasABottle()))));
         });
 
         $this->locations["Ganon's Tower - Randomizer Room - Bottom Right"]->setRequirements(function ($locations, $items) {
-            return $items->has('Hammer')
-                && $items->has('Hookshot')
-                && (
-                    ($locations->itemInLocations(Item::get('BigKeyA2', $this->world), [
+            return $items->has('Hammer') && $items->has('Hookshot')
+                && (($locations->itemInLocations(Item::get('BigKeyA2', $this->world), [
                         "Ganon's Tower - Randomizer Room - Top Right",
                         "Ganon's Tower - Randomizer Room - Top Left",
                         "Ganon's Tower - Randomizer Room - Bottom Left",
-                    ])
-                        && $items->has('KeyA2', 3)) ||
-                    $items->has('KeyA2', 4)) && ($items->has('MoonPearl')
+                    ]) && $items->has('KeyA2', 3))
+                        || $items->has('KeyA2', 4))
+                && ($items->has('MoonPearl')
                     || $this->world->config('canDungeonRevive', false)
-                    || (
-                        ($this->world->config('canOneFrameClipOW', false)
-                            || ($this->world->config('canBootsClip', false)
-                                && $items->has('PegasusBoots'))) && (
-                            ($this->world->config('canBunnyRevive', false)
-                                && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
-                                && $items->hasABottle()))));
+                    || (($this->world->config('canOneFrameClipOW', false)
+                            || ($this->world->config('canBootsClip', false) && $items->has('PegasusBoots')))
+                        && (($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
+                            || ($this->world->config('canOWYBA', false) && $items->hasABottle()))));
         });
 
         $this->locations["Ganon's Tower - Firesnake Room"]->setRequirements(function ($locations, $items) {
-            return $items->has('Hammer')
-                && $items->has('Hookshot')
-                && (
-                    (($locations->itemInLocations(Item::get('BigKeyA2', $this->world), [
+            return $items->has('Hammer') && $items->has('Hookshot')
+                && ((($locations->itemInLocations(Item::get('BigKeyA2', $this->world), [
                         "Ganon's Tower - Randomizer Room - Top Right",
                         "Ganon's Tower - Randomizer Room - Top Left",
                         "Ganon's Tower - Randomizer Room - Bottom Left",
                         "Ganon's Tower - Randomizer Room - Bottom Right",
-                    ])
-                        ||
-                        $locations["Ganon's Tower - Firesnake Room"]->hasItem(Item::get('KeyA2', $this->world))) &&
-                        $items->has('KeyA2', 2)) || $items->has('KeyA2', 3)) && ($items->has('MoonPearl')
-                        || $this->world->config('canDungeonRevive', false)
-                    || (
-                        ($this->world->config('canOneFrameClipOW', false)
-                            || ($this->world->config('canBootsClip', false)
-                                && $items->has('PegasusBoots'))) && (
-                            ($this->world->config('canBunnyRevive', false)
-                                && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
-                                && $items->hasABottle()))));
+                    ]) || $locations["Ganon's Tower - Firesnake Room"]->hasItem(Item::get('KeyA2', $this->world)))
+                        && $items->has('KeyA2', 2))
+                            || $items->has('KeyA2', 3))
+                && ($items->has('MoonPearl')
+                    || $this->world->config('canDungeonRevive', false)
+                    || (($this->world->config('canOneFrameClipOW', false)
+                            || ($this->world->config('canBootsClip', false) && $items->has('PegasusBoots')))
+                        && (($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
+                            || ($this->world->config('canOWYBA', false) && $items->hasABottle()))));
         });
 
         $this->locations["Ganon's Tower - Map Chest"]->setRequirements(function ($locations, $items) {
             return $items->has('Hammer')
                 && ($items->has('Hookshot')
-                    || ($this->world->config('itemPlacement') !== 'basic'
-                        && $items->has('PegasusBoots'))) && (in_array(
-                    $locations["Ganon's Tower - Map Chest"]->getItem(),
-                    [
+                    || ($this->world->config('itemPlacement') !== 'basic' && $items->has('PegasusBoots')))
+                && (in_array($locations["Ganon's Tower - Map Chest"]->getItem(), [
                         Item::get('BigKeyA2', $this->world),
                         Item::get('KeyA2', $this->world)
-                    ]
-                )
-                    ? $items->has('KeyA2', 3) : $items->has('KeyA2', 4)) && ($items->has('MoonPearl')
+                    ]) ? $items->has('KeyA2', 3) : $items->has('KeyA2', 4))
+                && ($items->has('MoonPearl')
                     || $this->world->config('canDungeonRevive', false)
-                    || (
-                        ($this->world->config('canOneFrameClipOW', false)
-                            || ($this->world->config('canBootsClip', false)
-                                && $items->has('PegasusBoots'))) && (
-                            ($this->world->config('canBunnyRevive', false)
-                                && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
-                                && $items->hasABottle()))));
+                    || (($this->world->config('canOneFrameClipOW', false)
+                            || ($this->world->config('canBootsClip', false) && $items->has('PegasusBoots')))
+                        && (($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
+                            || ($this->world->config('canOWYBA', false) && $items->hasABottle()))));
         })->setAlwaysAllow(function ($item, $items) {
-            return $this->world->config('accessibility') !== 'locations'
-                && $item == Item::get('KeyA2', $this->world)
-                && $items->has('KeyA2', 3);
+            return $this->world->config('accessibility') !== 'locations' && $item == Item::get('KeyA2', $this->world) && $items->has('KeyA2', 3);
         })->setFillRules(function ($item, $locations, $items) {
-            return $this->world->config('accessibility') !== 'locations'
-                || $item != Item::get('KeyA2', $this->world);
+            return $this->world->config('accessibility') !== 'locations' || $item != Item::get('KeyA2', $this->world);
         });
 
         $this->locations["Ganon's Tower - Big Chest"]->setRequirements(function ($locations, $items) {
-            return $items->has('BigKeyA2')
-                && $items->has('KeyA2', 3)
-                && (
-                    ($items->has('Hammer')
-                        && $items->has('Hookshot')) || ($items->has('FireRod')
-                        && $items->has('CaneOfSomaria'))) && ($items->has('MoonPearl')
+            return $items->has('BigKeyA2') && $items->has('KeyA2', 3)
+                && (($items->has('Hammer') && $items->has('Hookshot'))
+                    || ($items->has('FireRod') && $items->has('CaneOfSomaria')))
+                && ($items->has('MoonPearl')
                     || $this->world->config('canDungeonRevive', false)
-                    || (
-                        ($this->world->config('canOneFrameClipOW', false)
-                            || ($this->world->config('canBootsClip', false)
-                                && $items->has('PegasusBoots'))) && (
-                            ($this->world->config('canBunnyRevive', false)
-                                && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
-                                && $items->hasABottle()))));
+                    || (($this->world->config('canOneFrameClipOW', false)
+                            || ($this->world->config('canBootsClip', false) && $items->has('PegasusBoots')))
+                        && (($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
+                            || ($this->world->config('canOWYBA', false) && $items->hasABottle()))));
         })->setFillRules(function ($item, $locations, $items) {
             return $item != Item::get('BigKeyA2', $this->world);
         });
 
         $this->locations["Ganon's Tower - Bob's Chest"]->setRequirements(function ($locations, $items) {
-            return (($items->has('Hammer')
-                && $items->has('Hookshot')) || ($items->has('FireRod')
-                && $items->has('CaneOfSomaria'))) && $items->has('KeyA2', 3)
-                && ($items->has('MoonPearl') || $this->world->config('canDungeonRevive', false)
-                    || (
-                        ($this->world->config('canOneFrameClipOW', false)
-                            || ($this->world->config('canBootsClip', false)
-                                && $items->has('PegasusBoots'))) && (
-                            ($this->world->config('canBunnyRevive', false)
-                                && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
-                                && $items->hasABottle()))));
+            return (($items->has('Hammer') && $items->has('Hookshot'))
+                    || ($items->has('FireRod') && $items->has('CaneOfSomaria')))
+                && $items->has('KeyA2', 3)
+                && ($items->has('MoonPearl')
+                    || $this->world->config('canDungeonRevive', false)
+                    || (($this->world->config('canOneFrameClipOW', false)
+                            || ($this->world->config('canBootsClip', false) && $items->has('PegasusBoots')))
+                        && (($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
+                            || ($this->world->config('canOWYBA', false) && $items->hasABottle()))));
         });
 
         $this->locations["Ganon's Tower - Tile Room"]->setRequirements(function ($locations, $items) {
             return $items->has('CaneOfSomaria')
-                && ($items->has('MoonPearl') || $this->world->config('canDungeonRevive', false)
-                    || (
-                        ($this->world->config('canOneFrameClipOW', false)
-                            || ($this->world->config('canBootsClip', false)
-                                && $items->has('PegasusBoots'))) && (
-                            ($this->world->config('canBunnyRevive', false)
-                                && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
-                                && $items->hasABottle()))));
+                && ($items->has('MoonPearl')
+                    || $this->world->config('canDungeonRevive', false)
+                    || (($this->world->config('canOneFrameClipOW', false)
+                            || ($this->world->config('canBootsClip', false) && $items->has('PegasusBoots')))
+                        && (($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
+                            || ($this->world->config('canOWYBA', false) && $items->hasABottle()))));
         });
 
         $this->locations["Ganon's Tower - Compass Room - Top Left"]->setRequirements(function ($locations, $items) {
-            return $items->has('FireRod')
-                && $items->has('CaneOfSomaria')
-                && (
-                    ($locations->itemInLocations(Item::get('BigKeyA2', $this->world), [
+            return $items->has('FireRod') && $items->has('CaneOfSomaria')
+                && (($locations->itemInLocations(Item::get('BigKeyA2', $this->world), [
                         "Ganon's Tower - Compass Room - Top Right",
                         "Ganon's Tower - Compass Room - Bottom Left",
                         "Ganon's Tower - Compass Room - Bottom Right",
-                    ])
-                        && $items->has('KeyA2', 3)) ||
-                    $items->has('KeyA2', 4)) && ($items->has('MoonPearl')
-                        || $this->world->config('canDungeonRevive', false)
-                    || (
-                        ($this->world->config('canOneFrameClipOW', false)
-                            || ($this->world->config('canBootsClip', false)
-                                && $items->has('PegasusBoots'))) && (
-                            ($this->world->config('canBunnyRevive', false)
-                                && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
-                                && $items->hasABottle()))));
+                    ]) && $items->has('KeyA2', 3))
+                        || $items->has('KeyA2', 4))
+                && ($items->has('MoonPearl')
+                    || $this->world->config('canDungeonRevive', false)
+                    || (($this->world->config('canOneFrameClipOW', false)
+                            || ($this->world->config('canBootsClip', false) && $items->has('PegasusBoots')))
+                        && (($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
+                            || ($this->world->config('canOWYBA', false) && $items->hasABottle()))));
         });
 
         $this->locations["Ganon's Tower - Compass Room - Top Right"]->setRequirements(function ($locations, $items) {
-            return $items->has('FireRod')
-                && $items->has('CaneOfSomaria')
-                && (
-                    ($locations->itemInLocations(Item::get('BigKeyA2', $this->world), [
+            return $items->has('FireRod') && $items->has('CaneOfSomaria')
+                && (($locations->itemInLocations(Item::get('BigKeyA2', $this->world), [
                         "Ganon's Tower - Compass Room - Top Left",
                         "Ganon's Tower - Compass Room - Bottom Left",
                         "Ganon's Tower - Compass Room - Bottom Right",
-                    ])
-                        && $items->has('KeyA2', 3)) ||
-                    $items->has('KeyA2', 4)) && ($items->has('MoonPearl')
-                        || $this->world->config('canDungeonRevive', false)
-                    || (
-                        ($this->world->config('canOneFrameClipOW', false)
-                            || ($this->world->config('canBootsClip', false)
-                                && $items->has('PegasusBoots'))) && (
-                            ($this->world->config('canBunnyRevive', false)
-                                && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
-                                && $items->hasABottle()))));
+                    ]) && $items->has('KeyA2', 3))
+                        || $items->has('KeyA2', 4))
+                && ($items->has('MoonPearl')
+                    || $this->world->config('canDungeonRevive', false)
+                    || (($this->world->config('canOneFrameClipOW', false)
+                            || ($this->world->config('canBootsClip', false) && $items->has('PegasusBoots')))
+                        && (($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
+                            || ($this->world->config('canOWYBA', false) && $items->hasABottle()))));
         });
 
         $this->locations["Ganon's Tower - Compass Room - Bottom Left"]->setRequirements(function ($locations, $items) {
-            return $items->has('FireRod')
-                && $items->has('CaneOfSomaria')
-                && (
-                    ($locations->itemInLocations(Item::get('BigKeyA2', $this->world), [
+            return $items->has('FireRod') && $items->has('CaneOfSomaria')
+                && (($locations->itemInLocations(Item::get('BigKeyA2', $this->world), [
                         "Ganon's Tower - Compass Room - Top Right",
                         "Ganon's Tower - Compass Room - Top Left",
                         "Ganon's Tower - Compass Room - Bottom Right",
-                    ]) && $items->has('KeyA2', 3)) || $items->has('KeyA2', 4)) && ($items->has('MoonPearl')
-                        || $this->world->config('canDungeonRevive', false)
-                    || (
-                        ($this->world->config('canOneFrameClipOW', false)
-                            || ($this->world->config('canBootsClip', false)
-                                && $items->has('PegasusBoots'))) && (
-                            ($this->world->config('canBunnyRevive', false)
-                                && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
-                                && $items->hasABottle()))));
+                    ]) && $items->has('KeyA2', 3))
+                        || $items->has('KeyA2', 4))
+                && ($items->has('MoonPearl')
+                    || $this->world->config('canDungeonRevive', false)
+                    || (($this->world->config('canOneFrameClipOW', false)
+                            || ($this->world->config('canBootsClip', false) && $items->has('PegasusBoots')))
+                        && (($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
+                            || ($this->world->config('canOWYBA', false) && $items->hasABottle()))));
         });
 
         $this->locations["Ganon's Tower - Compass Room - Bottom Right"]->setRequirements(function ($locations, $items) {
-            return $items->has('FireRod')
-                && $items->has('CaneOfSomaria')
-                && (
-                    ($locations->itemInLocations(Item::get('BigKeyA2', $this->world), [
+            return $items->has('FireRod') && $items->has('CaneOfSomaria')
+                && (($locations->itemInLocations(Item::get('BigKeyA2', $this->world), [
                         "Ganon's Tower - Compass Room - Top Right",
                         "Ganon's Tower - Compass Room - Top Left",
                         "Ganon's Tower - Compass Room - Bottom Left",
-                    ]) && $items->has('KeyA2', 3)) ||
-                    $items->has('KeyA2', 4)) && ($items->has('MoonPearl')
-                        || $this->world->config('canDungeonRevive', false)
-                    || (
-                        ($this->world->config('canOneFrameClipOW', false)
-                            || ($this->world->config('canBootsClip', false)
-                                && $items->has('PegasusBoots'))) && (
-                            ($this->world->config('canBunnyRevive', false)
-                                && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
-                                && $items->hasABottle()))));
+                    ]) && $items->has('KeyA2', 3))
+                        || $items->has('KeyA2', 4))
+                && ($items->has('MoonPearl')
+                    || $this->world->config('canDungeonRevive', false)
+                    || (($this->world->config('canOneFrameClipOW', false)
+                            || ($this->world->config('canBootsClip', false) && $items->has('PegasusBoots')))
+                        && (($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
+                            || ($this->world->config('canOWYBA', false) && $items->hasABottle()))));
         });
 
         $this->locations["Ganon's Tower - Big Key Chest"]->setRequirements(function ($locations, $items) {
-            return (($items->has('Hammer')
-                && $items->has('Hookshot')) || ($items->has('FireRod')
-                && $items->has('CaneOfSomaria'))) && $items->has('KeyA2', 3)
+            return (($items->has('Hammer') && $items->has('Hookshot'))
+                    || ($items->has('FireRod') && $items->has('CaneOfSomaria')))
+                && $items->has('KeyA2', 3)
                 && $this->boss_bottom->canBeat($items, $locations)
                 && ($items->has('MoonPearl')
                     || $this->world->config('canDungeonRevive', false)
-                    || (
-                        ($this->world->config('canOneFrameClipOW', false)
-                            || ($this->world->config('canBootsClip', false)
-                                && $items->has('PegasusBoots'))) && (
-                            ($this->world->config('canBunnyRevive', false)
-                                && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
-                                && $items->hasABottle()))));
+                    || (($this->world->config('canOneFrameClipOW', false)
+                            || ($this->world->config('canBootsClip', false) && $items->has('PegasusBoots')))
+                        && (($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
+                            || ($this->world->config('canOWYBA', false) && $items->hasABottle()))));
         });
 
         $this->locations["Ganon's Tower - Big Key Room - Left"]->setRequirements(function ($locations, $items) {
-            return (($items->has('Hammer')
-                && $items->has('Hookshot')) || ($items->has('FireRod')
-                && $items->has('CaneOfSomaria'))) && $items->has('KeyA2', 3)
+            return (($items->has('Hammer') && $items->has('Hookshot'))
+                    || ($items->has('FireRod') && $items->has('CaneOfSomaria')))
+                && $items->has('KeyA2', 3)
                 && $this->boss_bottom->canBeat($items, $locations)
-                && ($items->has('MoonPearl') || $this->world->config('canDungeonRevive', false)
-                    || (
-                        ($this->world->config('canOneFrameClipOW', false)
-                            || ($this->world->config('canBootsClip', false)
-                                && $items->has('PegasusBoots'))) && (
-                            ($this->world->config('canBunnyRevive', false)
-                                && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
-                                && $items->hasABottle()))));
+                && ($items->has('MoonPearl')
+                    || $this->world->config('canDungeonRevive', false)
+                    || (($this->world->config('canOneFrameClipOW', false)
+                            || ($this->world->config('canBootsClip', false) && $items->has('PegasusBoots')))
+                        && (($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
+                            || ($this->world->config('canOWYBA', false) && $items->hasABottle()))));
         });
 
         $this->locations["Ganon's Tower - Big Key Room - Right"]->setRequirements(function ($locations, $items) {
-            return (($items->has('Hammer')
-                && $items->has('Hookshot')) || ($items->has('FireRod')
-                && $items->has('CaneOfSomaria'))) && $items->has('KeyA2', 3)
+            return (($items->has('Hammer') && $items->has('Hookshot'))
+                    || ($items->has('FireRod') && $items->has('CaneOfSomaria')))
+                && $items->has('KeyA2', 3)
                 && $this->boss_bottom->canBeat($items, $locations)
-                && ($items->has('MoonPearl') || $this->world->config('canDungeonRevive', false)
-                    || (
-                        ($this->world->config('canOneFrameClipOW', false)
-                            || ($this->world->config('canBootsClip', false)
-                                && $items->has('PegasusBoots'))) && (
-                            ($this->world->config('canBunnyRevive', false)
-                                && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
-                                && $items->hasABottle()))));
+                && ($items->has('MoonPearl')
+                    || $this->world->config('canDungeonRevive', false)
+                    || (($this->world->config('canOneFrameClipOW', false)
+                            || ($this->world->config('canBootsClip', false) && $items->has('PegasusBoots')))
+                        && (($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
+                            || ($this->world->config('canOWYBA', false) && $items->hasABottle()))));
         });
 
         $this->locations["Ganon's Tower - Mini Helmasaur Room - Left"]->setRequirements(function ($locations, $items) {
@@ -386,14 +307,12 @@ class GanonsTower extends Region\Standard\GanonsTower
                 && $items->has('BigKeyA2')
                 && $items->has('KeyA2', 3)
                 && $this->boss_middle->canBeat($items, $locations)
-                && ($items->has('MoonPearl') || $this->world->config('canDungeonRevive', false)
-                    || (
-                        ($this->world->config('canOneFrameClipOW', false)
-                            || ($this->world->config('canBootsClip', false)
-                                && $items->has('PegasusBoots'))) && (
-                            ($this->world->config('canBunnyRevive', false)
-                                && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
-                                && $items->hasABottle()))));
+                && ($items->has('MoonPearl')
+                    || $this->world->config('canDungeonRevive', false)
+                    || (($this->world->config('canOneFrameClipOW', false)
+                            || ($this->world->config('canBootsClip', false) && $items->has('PegasusBoots')))
+                        && (($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
+                            || ($this->world->config('canOWYBA', false) && $items->hasABottle()))));
         })->setFillRules(function ($item, $locations, $items) {
             return $item != Item::get('BigKeyA2', $this->world);
         });
@@ -404,14 +323,12 @@ class GanonsTower extends Region\Standard\GanonsTower
                 && $items->has('BigKeyA2')
                 && $items->has('KeyA2', 3)
                 && $this->boss_middle->canBeat($items, $locations)
-                && ($items->has('MoonPearl') || $this->world->config('canDungeonRevive', false)
-                    || (
-                        ($this->world->config('canOneFrameClipOW', false)
-                            || ($this->world->config('canBootsClip', false)
-                                && $items->has('PegasusBoots'))) && (
-                            ($this->world->config('canBunnyRevive', false)
-                                && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
-                                && $items->hasABottle()))));
+                && ($items->has('MoonPearl')
+                    || $this->world->config('canDungeonRevive', false)
+                    || (($this->world->config('canOneFrameClipOW', false)
+                            || ($this->world->config('canBootsClip', false) && $items->has('PegasusBoots')))
+                        && (($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
+                            || ($this->world->config('canOWYBA', false) && $items->hasABottle()))));
         })->setFillRules(function ($item, $locations, $items) {
             return $item != Item::get('BigKeyA2', $this->world);
         });
@@ -422,14 +339,12 @@ class GanonsTower extends Region\Standard\GanonsTower
                 && $items->has('BigKeyA2')
                 && $items->has('KeyA2', 3)
                 && $this->boss_middle->canBeat($items, $locations)
-                && ($items->has('MoonPearl') || $this->world->config('canDungeonRevive', false)
-                    || (
-                        ($this->world->config('canOneFrameClipOW', false)
-                            || ($this->world->config('canBootsClip', false)
-                                && $items->has('PegasusBoots'))) && (
-                            ($this->world->config('canBunnyRevive', false)
-                                && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
-                                && $items->hasABottle()))));
+                && ($items->has('MoonPearl')
+                    || $this->world->config('canDungeonRevive', false)
+                    || (($this->world->config('canOneFrameClipOW', false)
+                            || ($this->world->config('canBootsClip', false) && $items->has('PegasusBoots')))
+                        && (($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
+                            || ($this->world->config('canOWYBA', false) && $items->hasABottle()))));
         })->setFillRules(function ($item, $locations, $items) {
             return $item != Item::get('BigKeyA2', $this->world);
         });
@@ -442,14 +357,12 @@ class GanonsTower extends Region\Standard\GanonsTower
                 && $items->has('KeyA2', 4)
                 && $this->boss_middle->canBeat($items, $locations)
                 && $this->boss_top->canBeat($items, $locations)
-                && ($items->has('MoonPearl') || $this->world->config('canDungeonRevive', false)
-                    || (
-                        ($this->world->config('canOneFrameClipOW', false)
-                            || ($this->world->config('canBootsClip', false)
-                                && $items->has('PegasusBoots'))) && (
-                            ($this->world->config('canBunnyRevive', false)
-                                && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
-                                && $items->hasABottle()))));
+                && ($items->has('MoonPearl')
+                    || $this->world->config('canDungeonRevive', false)
+                    || (($this->world->config('canOneFrameClipOW', false)
+                            || ($this->world->config('canBootsClip', false) && $items->has('PegasusBoots')))
+                        && (($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
+                            || ($this->world->config('canOWYBA', false) && $items->hasABottle()))));
         })->setFillRules(function ($item, $locations, $items) {
             return $item != Item::get('KeyA2', $this->world)
                 && $item != Item::get('BigKeyA2', $this->world);
@@ -465,29 +378,23 @@ class GanonsTower extends Region\Standard\GanonsTower
 
         $this->can_enter = function ($locations, $items) {
             return ($this->world->config('itemPlacement') !== 'basic'
-                || (
-                    ($this->world->config('mode.weapons') === 'swordless'
-                        || $items->hasSword(2))
-                    && $items->hasHealth(12)
-                    && ($items->hasBottle(2)
-                        || $items->hasArmor()))) && ($this->world->config('canDungeonRevive', false)
-                || ($this->world->config('canSuperBunny', false)
-                    && $items->has('MagicMirror')) ||
-                $items->has('MoonPearl')
-                || (
-                    ($this->world->config('canOneFrameClipOW', false)
-                        || ($this->world->config('canBootsClip', false)
-                            && $items->has('PegasusBoots'))) && (
-                        ($this->world->config('canBunnyRevive', false)
-                            && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
-                            && $items->hasABottle())))) && ($items->has('Crystal1')
-                + $items->has('Crystal2')
-                + $items->has('Crystal3')
-                + $items->has('Crystal4')
-                + $items->has('Crystal5')
-                + $items->has('Crystal6')
-                + $items->has('Crystal7'))    >= $this->world->config('crystals.tower', 7)
-                && $this->world->getRegion('North East Light World')->canEnter($locations, $items);
+                    || (($this->world->config('mode.weapons') === 'swordless' || $items->hasSword(2))
+                        && $items->hasHealth(12) && ($items->hasBottle(2) || $items->hasArmor())))
+                && ($this->world->config('canDungeonRevive', false)
+                    || ($this->world->config('canSuperBunny', false) && $items->has('MagicMirror'))
+                    || $items->has('MoonPearl')
+                    || (($this->world->config('canOneFrameClipOW', false)
+                            || ($this->world->config('canBootsClip', false) && $items->has('PegasusBoots')))
+                        && (($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
+                            || ($this->world->config('canOWYBA', false) && $items->hasABottle()))))
+                && ($items->has('Crystal1')
+                        + $items->has('Crystal2')
+                        + $items->has('Crystal3')
+                        + $items->has('Crystal4')
+                        + $items->has('Crystal5')
+                        + $items->has('Crystal6')
+                        + $items->has('Crystal7')) >= $this->world->config('crystals.tower', 7)
+                    && $this->world->getRegion('North East Light World')->canEnter($locations, $items);
         };
 
         return $this;

--- a/app/Region/Inverted/HyruleCastleEscape.php
+++ b/app/Region/Inverted/HyruleCastleEscape.php
@@ -19,81 +19,88 @@ class HyruleCastleEscape extends Region\Open\HyruleCastleEscape
     public function initalize()
     {
         parent::initalize();
-        
+
         $this->locations["Sewers - Secret Room - Left"]->setRequirements(function ($locations, $items) {
-            return ($items->canLiftRocks() && ($items->has('MoonPearl')
-                || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
-                || ($this->world->config('canOWYBA', false) && $items->hasABottle())))
-                || ($items->has('Lamp', $this->world->config('item.require.Lamp', 1)) && $items->has('KeyH2')
-                && ($this->world->config('canDungeonRevive', false) || $items->hasSword()
-                    || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
-                    || ($this->world->config('canOWYBA', false) && $items->hasABottle())
-                    || $items->has('MoonPearl')));
+            return ($items->canLiftRocks()
+                    && ($items->has('MoonPearl')
+                        || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
+                        || ($this->world->config('canOWYBA', false) && $items->hasABottle())))
+                || ($items->has('Lamp', $this->world->config('item.require.Lamp', 1))
+                    && $items->has('KeyH2')
+                    && ($this->world->config('canDungeonRevive', false)
+                        || $items->hasSword()
+                        || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
+                        || ($this->world->config('canOWYBA', false) && $items->hasABottle())
+                        || $items->has('MoonPearl')));
         });
 
         $this->locations["Sewers - Secret Room - Middle"]->setRequirements(function ($locations, $items) {
-            return ($items->canLiftRocks() && ($items->has('MoonPearl')
-                || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
-                || ($this->world->config('canOWYBA', false) && $items->hasABottle())))
-                || ($items->has('Lamp', $this->world->config('item.require.Lamp', 1)) && $items->has('KeyH2')
-                && ($this->world->config('canDungeonRevive', false) || $items->hasSword()
-                    || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
-                    || ($this->world->config('canOWYBA', false) && $items->hasABottle())
-                    || $items->has('MoonPearl')));
+            return ($items->canLiftRocks()
+                    && ($items->has('MoonPearl')
+                        || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
+                        || ($this->world->config('canOWYBA', false) && $items->hasABottle())))
+                || ($items->has('Lamp', $this->world->config('item.require.Lamp', 1))
+                    && $items->has('KeyH2')
+                    && ($this->world->config('canDungeonRevive', false)
+                        || $items->hasSword()
+                        || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
+                        || ($this->world->config('canOWYBA', false) && $items->hasABottle())
+                        || $items->has('MoonPearl')));
         });
 
         $this->locations["Sewers - Secret Room - Right"]->setRequirements(function ($locations, $items) {
-            return ($items->canLiftRocks() && ($items->has('MoonPearl')
-                || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
-                || ($this->world->config('canOWYBA', false) && $items->hasABottle())))
-                || ($items->has('Lamp', $this->world->config('item.require.Lamp', 1)) && $items->has('KeyH2')
-                && ($this->world->config('canDungeonRevive', false) || $items->hasSword()
-                    || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
-                    || ($this->world->config('canOWYBA', false) && $items->hasABottle())
-                    || $items->has('MoonPearl')));
+            return ($items->canLiftRocks()
+                    && ($items->has('MoonPearl')
+                        || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
+                        || ($this->world->config('canOWYBA', false) && $items->hasABottle())))
+                || ($items->has('Lamp', $this->world->config('item.require.Lamp', 1))
+                    && $items->has('KeyH2')
+                    && ($this->world->config('canDungeonRevive', false)
+                        || $items->hasSword()
+                        || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
+                        || ($this->world->config('canOWYBA', false) && $items->hasABottle())
+                        || $items->has('MoonPearl')));
         });
 
         $this->locations["Hyrule Castle - Boomerang Chest"]->setRequirements(function ($locations, $items) {
-            return $items->has('KeyH2') && ($this->world->config('canDungeonRevive', false) || $items->hasSword()
-                || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
-                || ($this->world->config('canOWYBA', false) && $items->hasABottle())
-                || $items->has('MoonPearl'));
+            return $items->has('KeyH2')
+                && ($this->world->config('canDungeonRevive', false)
+                    || $items->hasSword()
+                    || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
+                    || ($this->world->config('canOWYBA', false) && $items->hasABottle())
+                    || $items->has('MoonPearl'));
         });
 
         $this->locations["Hyrule Castle - Zelda's Cell"]->setRequirements(function ($locations, $items) {
-            return $items->has('KeyH2') && ($this->world->config('canDungeonRevive', false) || $items->hasSword()
-                || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
-                || ($this->world->config('canOWYBA', false) && $items->hasABottle())
-                || $items->has('MoonPearl'));
+            return $items->has('KeyH2')
+                && ($this->world->config('canDungeonRevive', false)
+                    || $items->hasSword()
+                    || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
+                    || ($this->world->config('canOWYBA', false) && $items->hasABottle())
+                    || $items->has('MoonPearl'));
         });
 
         $this->locations["Sanctuary"]->setRequirements(function ($locations, $items) {
             return ($items->has('KeyH2') && $items->has('Lamp', $this->world->config('item.require.Lamp', 1)))
                 || (($items->has('MoonPearl')
-                    || ($this->world->config('canSuperBunny', false)
-                        && $items->has('MagicMirror'))
-                    || ($this->world->config('canOWYBA', false)
-                        && $items->hasABottle())
-                    || ($this->world->config('canBunnyRevive', false)
-                        && $items->canBunnyRevive()))
+                    || ($this->world->config('canSuperBunny', false) && $items->has('MagicMirror'))
+                    || ($this->world->config('canOWYBA', false) && $items->hasABottle())
+                    || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive()))
                     && $this->world->getRegion('North West Light World')->canEnter($locations, $items));
         });
 
         $this->locations["Secret Passage"]->setRequirements(function ($locations, $items) {
             return (
-                ($this->world->config('canMirrorClip', false)
-                    && $this->world->config('canSuperBunny', false)
-                    && $items->has('MagicMirror')
-                    && (
-                        ($this->world->config('canBootsClip', false)
-                            && $items->has('PegasusBoot')) || ($this->world->config('canSuperSpeed', false)
-                            && $items->canSpinSpeed()) ||
-                        $this->world->config('canOneFrameClipOW', false)) &&
-                    $this->world->getRegion('West Death Mountain')->canEnter($locations, $items)) || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
-                    && $items->hasABottle()) ||
-                $items->has('MoonPearl')) &&
-                $this->world->getRegion('North East Light World')->canEnter($locations, $items);
+                    ($this->world->config('canMirrorClip', false)
+                        && $this->world->config('canSuperBunny', false) && $items->has('MagicMirror')
+                        && (($this->world->config('canBootsClip', false) && $items->has('PegasusBoot'))
+                            || ($this->world->config('canSuperSpeed', false) && $items->canSpinSpeed())
+                            || $this->world->config('canOneFrameClipOW', false))
+                        && $this->world->getRegion('West Death Mountain')->canEnter($locations, $items))
+                    || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
+                    || ($this->world->config('canOWYBA', false) && $items->hasABottle())
+                    || $items->has('MoonPearl'))
+                && $this->world->getRegion('North East Light World')->canEnter($locations, $items);
         })->setFillRules(function ($item, $locations, $items) {
             return !((!$this->world->config('region.wildKeys', false) && $item instanceof Item\Key)
                 || (!$this->world->config('region.wildBigKeys', false) && $item instanceof Item\BigKey)
@@ -103,18 +110,16 @@ class HyruleCastleEscape extends Region\Open\HyruleCastleEscape
 
         $this->locations["Link's Uncle"]->setRequirements(function ($locations, $items) {
             return (
-                ($this->world->config('canMirrorClip', false)
-                    && $items->has('MagicMirror')
-                    && (
-                        ($this->world->config('canBootsClip', false)
-                            && $items->has('PegasusBoot')) || ($this->world->config('canSuperSpeed', false)
-                            && $items->canSpinSpeed()) ||
-                        $this->world->config('canOneFrameClipOW', false)) &&
-                    $this->world->getRegion('West Death Mountain')->canEnter($locations, $items)) || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
-                    && $items->hasABottle()) ||
-                $items->has('MoonPearl')) &&
-                $this->world->getRegion('North East Light World')->canEnter($locations, $items);
+                    ($this->world->config('canMirrorClip', false)
+                        && $items->has('MagicMirror')
+                        && (($this->world->config('canBootsClip', false) && $items->has('PegasusBoot'))
+                            || ($this->world->config('canSuperSpeed', false) && $items->canSpinSpeed())
+                            || $this->world->config('canOneFrameClipOW', false))
+                        && $this->world->getRegion('West Death Mountain')->canEnter($locations, $items))
+                    || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
+                    || ($this->world->config('canOWYBA', false) && $items->hasABottle())
+                    || $items->has('MoonPearl'))
+                && $this->world->getRegion('North East Light World')->canEnter($locations, $items);
         })->setFillRules(function ($item, $locations, $items) {
             return $this->locations["Sanctuary"]->canAccess($this->world->collectItems())
                 && !((!$this->world->config('region.wildKeys', false) && $item instanceof Item\Key)
@@ -126,12 +131,11 @@ class HyruleCastleEscape extends Region\Open\HyruleCastleEscape
 
         $this->can_enter = function ($locations, $items) {
             return ($this->world->config('canDungeonRevive', false)
-                || ($this->world->config('canSuperBunny', false)
-                    && $items->has('MagicMirror')) || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
-                    && $items->hasABottle()) ||
-                $items->has('MoonPearl')) &&
-                $this->world->getRegion('North East Light World')->canEnter($locations, $items);
+                    || ($this->world->config('canSuperBunny', false) && $items->has('MagicMirror'))
+                    || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
+                    || ($this->world->config('canOWYBA', false) && $items->hasABottle())
+                    || $items->has('MoonPearl'))
+                && $this->world->getRegion('North East Light World')->canEnter($locations, $items);
         };
 
         return $this;

--- a/app/Region/Inverted/IcePalace.php
+++ b/app/Region/Inverted/IcePalace.php
@@ -21,26 +21,21 @@ class IcePalace extends Region\Standard\IcePalace
 
         $this->can_enter = function ($locations, $items) {
             return ($this->world->config('itemPlacement') !== 'basic'
-                || (
-                    ($this->world->config('mode.weapons') === 'swordless'
-                        || $items->hasSword(2))
-                    && $items->hasHealth(12)
-                    && ($items->hasBottle(2)
-                        || $items->hasArmor()))) && ($items->canMeltThings($this->world)
-                || $this->world->config('canOneFrameClipUW', false)) && (($items->has('Flippers')
-                || ($this->world->config('canFakeFlipper', false)
-                    && ($this->world->config('canBunnyRevive', false)
-                    || (!$this->world->config('region.cantTakeDamage', false)
-                        && $this->world->getRegion('North West Dark World')->canEnter($locations, $items)) ||
-                    $items->canFly($this->world)
-                    || ($this->world->getRegion('North West Dark World')->canEnter($locations, $items)
-                        && ($items->has('Hammer')
-                            || $items->canLiftRocks()))))) || ($this->world->config('canBootsClip', false)
-                && $items->has('PegasusBoots'))
-                ||
-                $this->world->config('canOneFrameClipOW', false)
-                || ($this->world->config('canSuperSpeed', false)
-                    && $items->canSpinSpeed()));
+                    || (($this->world->config('mode.weapons') === 'swordless' || $items->hasSword(2))
+                            && $items->hasHealth(12) && ($items->hasBottle(2) || $items->hasArmor())))
+                && ($items->canMeltThings($this->world)
+                    || $this->world->config('canOneFrameClipUW', false))
+                && (($items->has('Flippers')
+                        || ($this->world->config('canFakeFlipper', false)
+                            && ($this->world->config('canBunnyRevive', false)
+                                || (!$this->world->config('region.cantTakeDamage', false)
+                                    && $this->world->getRegion('North West Dark World')->canEnter($locations, $items))
+                                || $items->canFly($this->world)
+                                || ($this->world->getRegion('North West Dark World')->canEnter($locations, $items)
+                                    && ($items->has('Hammer') || $items->canLiftRocks())))))
+                    || ($this->world->config('canBootsClip', false) && $items->has('PegasusBoots'))
+                    || $this->world->config('canOneFrameClipOW', false)
+                    || ($this->world->config('canSuperSpeed', false) && $items->canSpinSpeed()));
         };
 
         return $this;

--- a/app/Region/Inverted/LightWorld/DeathMountain/East.php
+++ b/app/Region/Inverted/LightWorld/DeathMountain/East.php
@@ -36,170 +36,139 @@ class East extends Region\Standard\LightWorld\DeathMountain\East
     {
         $this->shops["Light World Death Mountain Shop"]->setRequirements(function ($locations, $items) {
             return (($items->has('MoonPearl')
-                || ($this->world->config('canOWYBA', false)
-                    && $items->hasABottle(2))) && ($items->has('Hookshot')
-                || ($this->world->config('canSuperSpeed', false)
-                    && $items->canSpinSpeed())) || ($this->world->config('canOWYBA', false)
-                && $items->hasABottle()
-                && ((($this->world->config('canBootsClip', false)
-                    && $items->has('PegasusBoots')) ||
-                    $this->world->config('canOneFrameClipOW', false)))))
+                        || ($this->world->config('canOWYBA', false) && $items->hasABottle(2)))
+                    && ($items->has('Hookshot')
+                        || ($this->world->config('canSuperSpeed', false) && $items->canSpinSpeed()))
+                    || ($this->world->config('canOWYBA', false) && $items->hasABottle()
+                        && ((($this->world->config('canBootsClip', false) && $items->has('PegasusBoots'))
+                            || $this->world->config('canOneFrameClipOW', false)))))
                 && $items->canBombThings();
         });
 
-
         $this->locations["Spiral Cave"]->setRequirements(function ($locations, $items) {
-            return ($items->has('MoonPearl')) || ($this->world->config('canOWYBA', false)
-                && $items->hasABottle(2) && ($items->has('Hookshot') 
-                    || $this->world->config('canSuperSpeed', false)
-                    && $items->canSpinSpeed())) 
-                || ($this->world->config('canSuperBunny', false) && $items->has('MagicMirror')
-                && $items->hasSword()) 
-                || (($this->world->config('canOWYBA', false)
-                    && $items->hasABottle())
-                && (($this->world->config('canBootsClip', false)
-                    && $items->has('PegasusBoots')) 
-                    || $this->world->config('canOneFrameClipOW', false)));
+            return $items->has('MoonPearl')
+                || ($this->world->config('canOWYBA', false) && $items->hasABottle(2)
+                    && ($items->has('Hookshot')
+                        || $this->world->config('canSuperSpeed', false) && $items->canSpinSpeed()))
+                || ($this->world->config('canSuperBunny', false) && $items->has('MagicMirror') && $items->hasSword())
+                || (($this->world->config('canOWYBA', false) && $items->hasABottle())
+                    && (($this->world->config('canBootsClip', false) && $items->has('PegasusBoots'))
+                        || $this->world->config('canOneFrameClipOW', false)));
         });
 
         $this->locations["Mimic Cave"]->setRequirements(function ($locations, $items) {
             return $items->has('Hammer')
                 && ($items->has('MoonPearl')
-                    || (($this->world->config('canOWYBA', false)
-                        && $items->hasABottle()) && (
-                        ($this->world->config('canBootsClip', false)
-                            && $items->has('PegasusBoots')) ||
-                        $this->world->config('canOneFrameClipOW', false))));
+                    || (($this->world->config('canOWYBA', false) && $items->hasABottle())
+                        && (($this->world->config('canBootsClip', false) && $items->has('PegasusBoots'))
+                            || $this->world->config('canOneFrameClipOW', false))));
         });
 
         $this->locations["Paradox Cave Lower - Far Left"]->setRequirements(function ($locations, $items) {
             return $items->has('MoonPearl')
-                || ($this->world->config('canOWYBA', false)
-                    && $items->hasABottle(2) && ($items->has('Hookshot')
-                        || ($this->world->config('canSuperSpeed', false)
-                        && $items->canSpinSpeed()))) || ($this->world->config('canOWYBA', false)
-                && $items->hasABottle()
-                && (($this->world->config('canBootsClip', false)
-                    && $items->has('PegasusBoots'))
-                    || $this->world->config('canOneFrameClipOW', false)));
+                || ($this->world->config('canOWYBA', false) && $items->hasABottle(2)
+                    && ($items->has('Hookshot')
+                        || ($this->world->config('canSuperSpeed', false) && $items->canSpinSpeed())))
+                || ($this->world->config('canOWYBA', false) && $items->hasABottle()
+                    && (($this->world->config('canBootsClip', false) && $items->has('PegasusBoots'))
+                        || $this->world->config('canOneFrameClipOW', false)));
         });
 
         $this->locations["Paradox Cave Lower - Left"]->setRequirements(function ($locations, $items) {
             return $items->has('MoonPearl')
-                || ($this->world->config('canOWYBA', false)
-                    && $items->hasABottle(2) && ($items->has('Hookshot')
-                        || ($this->world->config('canSuperSpeed', false)
-                        && $items->canSpinSpeed()))) || ($this->world->config('canOWYBA', false)
-                && $items->hasABottle()
-                && (($this->world->config('canBootsClip', false)
-                    && $items->has('PegasusBoots'))
-                    || $this->world->config('canOneFrameClipOW', false)));
+                || ($this->world->config('canOWYBA', false) && $items->hasABottle(2)
+                    && ($items->has('Hookshot')
+                        || ($this->world->config('canSuperSpeed', false) && $items->canSpinSpeed())))
+                || ($this->world->config('canOWYBA', false) && $items->hasABottle()
+                    && (($this->world->config('canBootsClip', false) && $items->has('PegasusBoots'))
+                        || $this->world->config('canOneFrameClipOW', false)));
         });
 
         $this->locations["Paradox Cave Lower - Right"]->setRequirements(function ($locations, $items) {
             return $items->has('MoonPearl')
-                || ($this->world->config('canOWYBA', false)
-                    && $items->hasABottle(2) && ($items->has('Hookshot')
-                        || ($this->world->config('canSuperSpeed', false)
-                        && $items->canSpinSpeed()))) || ($this->world->config('canOWYBA', false)
-                && $items->hasABottle()
-                && (($this->world->config('canBootsClip', false)
-                    && $items->has('PegasusBoots'))
-                    || $this->world->config('canOneFrameClipOW', false)));
+                || ($this->world->config('canOWYBA', false) && $items->hasABottle(2)
+                    && ($items->has('Hookshot')
+                        || ($this->world->config('canSuperSpeed', false) && $items->canSpinSpeed())))
+                || ($this->world->config('canOWYBA', false) && $items->hasABottle()
+                    && (($this->world->config('canBootsClip', false) && $items->has('PegasusBoots'))
+                        || $this->world->config('canOneFrameClipOW', false)));
         });
 
         $this->locations["Paradox Cave Lower - Far Right"]->setRequirements(function ($locations, $items) {
             return $items->has('MoonPearl')
-                || ($this->world->config('canOWYBA', false)
-                    && $items->hasABottle(2) && ($items->has('Hookshot')
-                        || ($this->world->config('canSuperSpeed', false)
-                        && $items->canSpinSpeed()))) || ($this->world->config('canOWYBA', false)
-                && $items->hasABottle()
-                && (($this->world->config('canBootsClip', false)
-                    && $items->has('PegasusBoots'))
-                    || $this->world->config('canOneFrameClipOW', false)));
+                || ($this->world->config('canOWYBA', false) && $items->hasABottle(2)
+                    && ($items->has('Hookshot')
+                        || ($this->world->config('canSuperSpeed', false) && $items->canSpinSpeed())))
+                || ($this->world->config('canOWYBA', false) && $items->hasABottle()
+                    && (($this->world->config('canBootsClip', false) && $items->has('PegasusBoots'))
+                        || $this->world->config('canOneFrameClipOW', false)));
         });
 
         $this->locations["Paradox Cave Lower - Middle"]->setRequirements(function ($locations, $items) {
             return $items->has('MoonPearl')
-                || ($this->world->config('canOWYBA', false)
-                    && $items->hasABottle(2) && ($items->has('Hookshot')
-                        || ($this->world->config('canSuperSpeed', false)
-                        && $items->canSpinSpeed()))) || ($this->world->config('canOWYBA', false)
-                && $items->hasABottle()
-                && (($this->world->config('canBootsClip', false)
-                    && $items->has('PegasusBoots'))
-                    || $this->world->config('canOneFrameClipOW', false)));
+                || ($this->world->config('canOWYBA', false) && $items->hasABottle(2)
+                    && ($items->has('Hookshot')
+                        || ($this->world->config('canSuperSpeed', false) && $items->canSpinSpeed())))
+                || ($this->world->config('canOWYBA', false) && $items->hasABottle()
+                    && (($this->world->config('canBootsClip', false) && $items->has('PegasusBoots'))
+                        || $this->world->config('canOneFrameClipOW', false)));
         });
 
         $this->locations["Paradox Cave Upper - Left"]->setRequirements(function ($locations, $items) {
             return $items->canBombThings()
                 && ($items->has('MoonPearl')
-                    || ($this->world->config('canOWYBA', false)
-                        && $items->hasABottle(2) && ($items->has('Hookshot')
-                            || ($this->world->config('canSuperSpeed', false)
-                                && $items->canSpinSpeed())))
+                    || ($this->world->config('canOWYBA', false) && $items->hasABottle(2)
+                        && ($items->has('Hookshot')
+                            || ($this->world->config('canSuperSpeed', false) && $items->canSpinSpeed())))
                     || ($this->world->config('canOWYBA', false) && $items->hasABottle()
-                    && (($this->world->config('canBootsClip', false)
-                        && $items->has('PegasusBoots'))
-                        || $this->world->config('canOneFrameClipOW', false))));
+                        && (($this->world->config('canBootsClip', false) && $items->has('PegasusBoots'))
+                            || $this->world->config('canOneFrameClipOW', false))));
         });
 
         $this->locations["Paradox Cave Upper - Right"]->setRequirements(function ($locations, $items) {
             return $items->canBombThings()
                 && ($items->has('MoonPearl')
-                    || ($this->world->config('canOWYBA', false)
-                        && $items->hasABottle(2) && ($items->has('Hookshot')
-                            || ($this->world->config('canSuperSpeed', false)
-                                && $items->canSpinSpeed())))
+                    || ($this->world->config('canOWYBA', false) && $items->hasABottle(2)
+                        && ($items->has('Hookshot')
+                            || ($this->world->config('canSuperSpeed', false) && $items->canSpinSpeed())))
                     || ($this->world->config('canOWYBA', false) && $items->hasABottle()
-                    && (($this->world->config('canBootsClip', false)
-                        && $items->has('PegasusBoots'))
-                        || $this->world->config('canOneFrameClipOW', false))));
+                        && (($this->world->config('canBootsClip', false) && $items->has('PegasusBoots'))
+                            || $this->world->config('canOneFrameClipOW', false))));
         });
 
         $this->locations["Ether Tablet"]->setRequirements(function ($locations, $items) {
             return $items->has('BookOfMudora')
-                && (($this->world->config('mode.weapons') == 'swordless'
-                    && $items->has('Hammer'))
-                    || $items->hasSword(2)) && (($items->has('MoonPearl')
+                && (($this->world->config('mode.weapons') == 'swordless' && $items->has('Hammer')) || $items->hasSword(2))
+                && (($items->has('MoonPearl')
                     && ($items->has('Hammer')
-                    || ($this->world->config('canBootsClip', false)
-                        && $items->has('PegasusBoots')) || ($this->world->config('canSuperSpeed', false)
-                        && $items->canSpinSpeed())
-                        || ($this->world->config('canOWYBA', false)
-                            && $items->hasABottle()
-                            && $this->world->config('canBootsClip', false)
-                            && $items->has('PegasusBoots'))))
-                    || $this->world->config('canOneFrameClipOW', false)
-                );
+                        || ($this->world->config('canBootsClip', false) && $items->has('PegasusBoots'))
+                        || ($this->world->config('canSuperSpeed', false) && $items->canSpinSpeed())
+                        || ($this->world->config('canOWYBA', false) && $items->hasABottle()
+                            && $this->world->config('canBootsClip', false) && $items->has('PegasusBoots'))))
+                    || $this->world->config('canOneFrameClipOW', false));
         });
 
         $this->locations["Spectacle Rock"]->setRequirements(function ($locations, $items) {
             return ($items->has('MoonPearl')
-                && ($items->has('Hammer')
-                    || ($this->world->config('canSuperSpeed', false)
-                        && $items->canSpinSpeed()) || ($this->world->config('canBootsClip', false)
-                        && $items->has('PegasusBoots')))) || ($this->world->config('canOWYBA', false)
-                && $items->hasABottle()
-                && $this->world->config('canBootsClip', false)
-                && $items->has('PegasusBoots')) ||
-                $this->world->config('canOneFrameClipOW', false);
+                    && ($items->has('Hammer')
+                        || ($this->world->config('canSuperSpeed', false) && $items->canSpinSpeed())
+                        || ($this->world->config('canBootsClip', false) && $items->has('PegasusBoots'))))
+                || ($this->world->config('canOWYBA', false) && $items->hasABottle()
+                    && $this->world->config('canBootsClip', false) && $items->has('PegasusBoots'))
+                || $this->world->config('canOneFrameClipOW', false);
         });
 
         $this->can_enter = function ($locations, $items) {
             return ($items->canLiftDarkRocks()
-                && $this->world->getRegion('East Dark World Death Mountain')->canEnter($locations, $items)) || ($this->world->getRegion('West Death Mountain')->canEnter($locations, $items)
-                && (
-                    (($items->has('MoonPearl')
-                        || ($this->world->config('canOWYBA', false)
-                            && $items->hasABottle(2))) && ($items->has('Hookshot')
-                        || ($this->world->config('canBootsClip', false)
-                            && $items->has('PegasusBoots')) || ($this->world->config('canSuperSpeed', false)
-                            && $items->canSpinSpeed()))) 
-                    || ($this->world->config('canMirrorWrap', false)
-                        && $items->has('MagicMirror')) ||
-                    $this->world->config('canOneFrameClipOW', false)));
+                    && $this->world->getRegion('East Dark World Death Mountain')->canEnter($locations, $items))
+                || ($this->world->getRegion('West Death Mountain')->canEnter($locations, $items)
+                    && ((($items->has('MoonPearl')
+                            || ($this->world->config('canOWYBA', false) && $items->hasABottle(2)))
+                        && ($items->has('Hookshot')
+                            || ($this->world->config('canBootsClip', false) && $items->has('PegasusBoots'))
+                            || ($this->world->config('canSuperSpeed', false) && $items->canSpinSpeed())))
+                        || ($this->world->config('canMirrorWrap', false) && $items->has('MagicMirror'))
+                        || $this->world->config('canOneFrameClipOW', false)));
         };
 
         return $this;

--- a/app/Region/Inverted/LightWorld/DeathMountain/West.php
+++ b/app/Region/Inverted/LightWorld/DeathMountain/West.php
@@ -40,11 +40,10 @@ class West extends Region\Standard\LightWorld\DeathMountain\West
         $this->can_enter = function ($locations, $items) {
             return $items->canFly($this->world)
                 || ($items->canLiftRocks()
-                    && $items->has('Lamp', $this->world->config('item.require.Lamp', 1))) || ($this->world->config('canBootsClip', false)
-                    && $items->has('PegasusBoots')) ||
-                $this->world->config('canOneFrameClipOW', false)
-                || ($this->world->config('canOWYBA', false)
-                    && $items->hasABottle());
+                    && $items->has('Lamp', $this->world->config('item.require.Lamp', 1)))
+                || ($this->world->config('canBootsClip', false) && $items->has('PegasusBoots'))
+                || $this->world->config('canOneFrameClipOW', false)
+                || ($this->world->config('canOWYBA', false) && $items->hasABottle());
         };
 
         return $this;

--- a/app/Region/Inverted/LightWorld/NorthEast.php
+++ b/app/Region/Inverted/LightWorld/NorthEast.php
@@ -31,33 +31,27 @@ class NorthEast extends Region\Standard\LightWorld\NorthEast
     {
         $this->locations["Sahasrahla's Hut - Left"]->setRequirements(function ($locations, $items) {
             return (($items->has('MoonPearl')
-                || ($this->world->config('canOWYBA', false)
-                    && $items->hasABottle()))
-                && $items->canBombThings())
-                || ($this->world->config('canSuperBunny', false)
-                    && $items->has('PegasusBoots')
+                        || ($this->world->config('canOWYBA', false) && $items->hasABottle()))
+                    && $items->canBombThings())
+                || ($this->world->config('canSuperBunny', false) && $items->has('PegasusBoots')
                     && ($items->has('MagicMirror')
                         || !$this->world->config('region.cantTakeDamage', false)));
         });
 
         $this->locations["Sahasrahla's Hut - Middle"]->setRequirements(function ($locations, $items) {
             return (($items->has('MoonPearl')
-                || ($this->world->config('canOWYBA', false)
-                    && $items->hasABottle()))
-                && $items->canBombThings())
-                || ($this->world->config('canSuperBunny', false)
-                    && $items->has('PegasusBoots')
+                        || ($this->world->config('canOWYBA', false) && $items->hasABottle()))
+                    && $items->canBombThings())
+                || ($this->world->config('canSuperBunny', false) && $items->has('PegasusBoots')
                     && ($items->has('MagicMirror')
                         || !$this->world->config('region.cantTakeDamage', false)));
         });
 
         $this->locations["Sahasrahla's Hut - Right"]->setRequirements(function ($locations, $items) {
             return (($items->has('MoonPearl')
-                || ($this->world->config('canOWYBA', false)
-                    && $items->hasABottle()))
-                && $items->canBombThings())
-                || ($this->world->config('canSuperBunny', false)
-                    && $items->has('PegasusBoots')
+                        || ($this->world->config('canOWYBA', false) && $items->hasABottle()))
+                    && $items->canBombThings())
+                || ($this->world->config('canSuperBunny', false) && $items->has('PegasusBoots')
                     && ($items->has('MagicMirror')
                         || !$this->world->config('region.cantTakeDamage', false)));
         });
@@ -68,77 +62,64 @@ class NorthEast extends Region\Standard\LightWorld\NorthEast
 
         $this->locations["King Zora"]->setRequirements(function ($locations, $items) {
             return ($items->has('MoonPearl')
-                || ($this->world->config('canOWYBA', false)
-                    && $items->hasABottle())) && ($items->canLiftRocks()
-                || ($this->world->config('canFakeFlipper', false)
-                    || $items->has('Flippers')) || (
-                    ($this->world->config('canBootsClip', false)
-                        || $this->world->config('canWaterWalk', false)) &&
-                    $items->has('PegasusBoots')) || ($this->world->config('canSuperSpeed', false)
-                    && $items->canSpinSpeed()
-                    && $this->world->getRegion('East Death Mountain')->canEnter($locations, $items))) ||
-                $this->world->config('canOneFrameClipOW', false);
+                    || ($this->world->config('canOWYBA', false) && $items->hasABottle()))
+                && ($items->canLiftRocks()
+                    || ($this->world->config('canFakeFlipper', false) || $items->has('Flippers'))
+                    || (($this->world->config('canBootsClip', false) || $this->world->config('canWaterWalk', false))
+                        && $items->has('PegasusBoots'))
+                    || ($this->world->config('canSuperSpeed', false) && $items->canSpinSpeed()
+                        && $this->world->getRegion('East Death Mountain')->canEnter($locations, $items)))
+                || $this->world->config('canOneFrameClipOW', false);
         });
 
         $this->locations["Potion Shop"]->setRequirements(function ($locations, $items) {
             return ($items->has('MoonPearl')
-                || ($this->world->config('canOWYBA', false)
-                    && $items->hasABottle())
-                || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive())
-                || $this->world->config('canOneFrameClipOW', false)) &&
-                $items->has('Mushroom');
+                    || ($this->world->config('canOWYBA', false) && $items->hasABottle())
+                    || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
+                    || $this->world->config('canOneFrameClipOW', false))
+                && $items->has('Mushroom');
         });
 
         $this->locations["Zora's Ledge"]->setRequirements(function ($locations, $items) {
             return ($items->has('MoonPearl')
-                || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
-                    && $items->hasABottle())) && ($items->has('Flippers')
+                    || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
+                    || ($this->world->config('canOWYBA', false) && $items->hasABottle()))
+                && ($items->has('Flippers')
                     || ($this->world->config('canWaterWalk', false)
-                        && (($this->world->config('canFakeFlipper', false)
-                            && $this->world->config('canWaterWalk', false)
-                            && $items->has('MoonPearl')
-                            && $this->world->config('canOneFrameClipOW', false))
-                        || (($this->world->config('canBootsClip', false)
-                            || $this->world->config('canOneFrameClipOW', false)
-                            || ($this->world->config('canSuperSpeed', false)
-                                && $items->canSpinSpeed()))
+                        && (($this->world->config('canFakeFlipper', false) && $this->world->config('canWaterWalk', false) && $items->has('MoonPearl')
+                                && $this->world->config('canOneFrameClipOW', false))
+                            || (($this->world->config('canBootsClip', false)
+                                    || $this->world->config('canOneFrameClipOW', false)
+                                    || ($this->world->config('canSuperSpeed', false) && $items->canSpinSpeed()))
                                 && $items->has('PegasusBoots')))));
         });
 
         $this->locations["Waterfall Fairy - Left"]->setRequirements(function ($locations, $items) {
             return ($items->has('MoonPearl')
-                || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
-                    && $items->hasABottle())) && ($this->world->config('canFakeFlipper', false)
-                || ($this->world->config('canWaterWalk', false)
-                    && ($items->has('PegasusBoots')
-                        || $items->has('MoonPearl'))) ||
-                $items->has('Flippers')
-                || ($this->world->getRegion('East Death Mountain')->canEnter($locations, $items)
-                    && (
-                        ($this->world->config('canBootsClip', false)
-                            && $items->has('PegasusBoots')) || ($this->world->config('canSuperSpeed', false)
-                            && $items->canSpinSpeed()) ||
-                        $this->world->config('canOneFrameClipOW', false))));
+                    || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
+                    || ($this->world->config('canOWYBA', false) && $items->hasABottle()))
+                && ($this->world->config('canFakeFlipper', false)
+                    || ($this->world->config('canWaterWalk', false)
+                        && ($items->has('PegasusBoots') || $items->has('MoonPearl')))
+                    || $items->has('Flippers')
+                    || ($this->world->getRegion('East Death Mountain')->canEnter($locations, $items)
+                        && (($this->world->config('canBootsClip', false) && $items->has('PegasusBoots'))
+                            || ($this->world->config('canSuperSpeed', false) && $items->canSpinSpeed())
+                            || $this->world->config('canOneFrameClipOW', false))));
         });
 
         $this->locations["Waterfall Fairy - Right"]->setRequirements(function ($locations, $items) {
             return ($items->has('MoonPearl')
-                || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
-                    && $items->hasABottle())) && ($this->world->config('canFakeFlipper', false)
-                || ($this->world->config('canWaterWalk', false)
-                    && ($items->has('PegasusBoots')
-                        || $items->has('MoonPearl'))) ||
-                $items->has('Flippers')
-                || ($this->world->getRegion('East Death Mountain')->canEnter($locations, $items)
-                    && (
-                        ($this->world->config('canBootsClip', false)
-                            && $items->has('PegasusBoots')) || ($this->world->config('canSuperSpeed', false)
-                            && $items->canSpinSpeed()) ||
-                        $this->world->config('canOneFrameClipOW', false))));
+                    || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
+                    || ($this->world->config('canOWYBA', false) && $items->hasABottle()))
+                && ($this->world->config('canFakeFlipper', false)
+                    || ($this->world->config('canWaterWalk', false)
+                        && ($items->has('PegasusBoots') || $items->has('MoonPearl')))
+                    || $items->has('Flippers')
+                    || ($this->world->getRegion('East Death Mountain')->canEnter($locations, $items)
+                        && (($this->world->config('canBootsClip', false) && $items->has('PegasusBoots'))
+                            || ($this->world->config('canSuperSpeed', false) && $items->canSpinSpeed())
+                            || $this->world->config('canOneFrameClipOW', false))));
         });
 
         $this->prize_location->setRequirements(function ($locations, $items) {
@@ -174,45 +155,49 @@ class NorthEast extends Region\Standard\LightWorld\NorthEast
             }
 
             return ($items->has('MoonPearl')
-                || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
-                    && $items->hasABottle()) || (     // Invis Ganon fight sounds fun for logic :)
-                    $this->world->config('canSuperBunny', false)
-                    && $this->world->config('canDungeonRevive', false) // Just so it's not in logic for everyone. Don't care, just think it's better like this.
-                    && $this->world->getRegion('Ganons Tower')->canEnter($locations, $items) //Bunny Beam Storage from GT
-                    && $items->has('CaneOfSomaria')
-                    && $items->has('MagicMirror')
-                    && $items->hasABottle() // Magic should be easily fine, but it's easy to miss when Invisible, even with lamp. FRod when Requires a bunch of Bottles anyway.
-                )) && ($items->has('DefeatAgahnim2')
-                || $this->world->config('goal') === 'fast_ganon')
+                    || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
+                    || ($this->world->config('canOWYBA', false) && $items->hasABottle())
+                    || ( // Invis Ganon fight sounds fun for logic :)
+                        $this->world->config('canSuperBunny', false)
+                        && $this->world->config('canDungeonRevive', false) // Just so it's not in logic for everyone. Don't care, just think it's better like this.
+                        && $this->world->getRegion('Ganons Tower')->canEnter($locations, $items) //Bunny Beam Storage from GT
+                        && $items->has('CaneOfSomaria')
+                        && $items->has('MagicMirror')
+                        && $items->hasABottle() // Magic should be easily fine, but it's easy to miss when Invisible, even with lamp. FRod when Requires a bunch of Bottles anyway.
+                ))
+                && ($items->has('DefeatAgahnim2')
+                    || $this->world->config('goal') === 'fast_ganon')
                 && (!$this->world->config('region.requireBetterBow', false)
-                    || $items->canShootArrows($this->world, 2)) && (
-                    ($this->world->config('mode.weapons') == 'swordless'
-                        && $items->has('Hammer') && ($items->has('Lamp', $this->world->config('item.require.Lamp', 1))
-                            || ($items->has('FireRod') && ($items->canExtendMagic(1)
-                                && $items->has('MoonPearl')) || $items->canExtendMagic(4)))) 
+                    || $items->canShootArrows($this->world, 2))
+                && (($this->world->config('mode.weapons') == 'swordless' && $items->has('Hammer')
+                    && ($items->has('Lamp', $this->world->config('item.require.Lamp', 1))
+                        || ($items->has('FireRod')
+                            && ($items->canExtendMagic(1)
+                                && $items->has('MoonPearl'))
+                            || $items->canExtendMagic(4)))) 
                     || (!$this->world->config('region.requireBetterSword', false)
                         && ($items->hasSword(2)
                             && ($items->has('Lamp', $this->world->config('item.require.Lamp', 1))
                                 || ($items->has('FireRod')
                                     && ($items->canExtendMagic(3)
-                                        && $items->has('MoonPearl')) ||
-                                    $items->canExtendMagic(4))))) || ($items->hasSword(3)
+                                        && $items->has('MoonPearl'))
+                                    || $items->canExtendMagic(4)))))
+                    || ($items->hasSword(3)
                         && ($items->has('Lamp', $this->world->config('item.require.Lamp', 1))
                             || ($items->has('FireRod')
                                 && ($items->canExtendMagic(2)
-                                    && $items->has('MoonPearl')) ||
-                                $items->canExtendMagic(3)))));
+                                    && $items->has('MoonPearl'))
+                                || $items->canExtendMagic(3)))));
         });
 
         $this->can_enter = function ($locations, $items) {
             return
                 $items->has('DefeatAgahnim')
                 || ($items->has('MoonPearl')
-                    && (
-                        ($items->has('Hammer')
-                            && $items->canLiftRocks()) ||
-                        $items->canLiftDarkRocks())) || (
+                    && (($items->has('Hammer')
+                            && $items->canLiftRocks())
+                        || $items->canLiftDarkRocks()))
+                || (
                     // Glitched Access from DeathMountain
                     $this->world->config('canOWYBA', false)
                     && ($items->hasABottle(2)
@@ -220,11 +205,9 @@ class NorthEast extends Region\Standard\LightWorld\NorthEast
                             && $items->has('Lamp', $this->world->config('item.require.Lamp', 1)))))
                 || ($this->world->getRegion('West Death Mountain')->canEnter($locations, $items)
                     && ($items->has('MoonPearl') || $items->has('MagicMirror'))
-                    && (
-                        ($this->world->config('canSuperSpeed', false)
-                            && $items->canSpinSpeed()) || ($this->world->config('canBootsClip', false)
-                            && $items->has('PegasusBoots')))) ||
-                $this->world->config('canOneFrameClipOW', false);
+                    && (($this->world->config('canSuperSpeed', false) && $items->canSpinSpeed())
+                        || ($this->world->config('canBootsClip', false) && $items->has('PegasusBoots'))))
+                || $this->world->config('canOneFrameClipOW', false);
         };
 
         return $this;

--- a/app/Region/Inverted/LightWorld/NorthWest.php
+++ b/app/Region/Inverted/LightWorld/NorthWest.php
@@ -19,17 +19,15 @@ class NorthWest extends Region\Standard\LightWorld\NorthWest
     {
         $this->shops["Bush Covered House"]->setRequirements(function ($locations, $items) {
             return $items->has('MoonPearl')
-                || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
-                    && $items->hasABottle());
+                || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
+                || ($this->world->config('canOWYBA', false) && $items->hasABottle());
         });
 
         $this->shops["Bomb Hut"]->setRequirements(function ($locations, $items) {
-            return $items->has('MoonPearl')
-                || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
-                    && $items->hasABottle()) &&
-                $items->canBombThings();
+            return ($items->has('MoonPearl')
+                    || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
+                    || ($this->world->config('canOWYBA', false) && $items->hasABottle()))
+                && $items->canBombThings();
         });
 
         // Bunny can pull pedestal
@@ -42,138 +40,118 @@ class NorthWest extends Region\Standard\LightWorld\NorthWest
         $this->locations["King's Tomb"]->setRequirements(function ($locations, $items) {
             return $items->has('PegasusBoots')
                 && ($items->has('MoonPearl')
-                    || ($this->world->config('canBunnyRevive', false)
-                        && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
-                        && $items->hasABottle())) && ($items->canLiftDarkRocks()
-                    || ($this->world->config('canMirrorClip', false)
-                        && $items->has('MagicMirror')
-                        && $items->has('MoonPearl')
-                        && ($this->world->config('canBootsClip', false)
-                            && $items->has('PegasusBoots')) ||
-                        $this->world->config('canOneFrameClipOW', false)
+                    || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
+                    || ($this->world->config('canOWYBA', false) && $items->hasABottle()))
+                && ($items->canLiftDarkRocks()
+                    || ($this->world->config('canMirrorClip', false) && $items->has('MagicMirror') && $items->has('MoonPearl')
+                            && ($this->world->config('canBootsClip', false) && $items->has('PegasusBoots'))
+                        || $this->world->config('canOneFrameClipOW', false)
                         || ($this->world->getRegion('East Death Mountain')->canEnter($locations, $items)
-                            && ($this->world->config('canSuperSpeed', false)
-                                && $items->canSpinSpeed()
+                            && ($this->world->config('canSuperSpeed', false) && $items->canSpinSpeed()
                                 && ($items->has('MoonPearl')
-                                    || ($this->world->config('canOWYBA', false)
-                                        && $items->hasABottle(2)))))));
+                                    || ($this->world->config('canOWYBA', false) && $items->hasABottle(2)))))));
         });
 
         $this->locations["Kakariko Tavern"]->setRequirements(function ($locations, $items) {
             return $items->has('MoonPearl')
                 || ($this->world->config('canSuperBunny', false)
-                    && ($items->has('MagicMirror') || !$this->world->config('cantTakeDamage', false))) 
-                    || ($this->world->config('canOWYBA', false)
-                    && $items->hasABottle()) || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive());
+                    && ($items->has('MagicMirror') || !$this->world->config('cantTakeDamage', false)))
+                || ($this->world->config('canOWYBA', false) && $items->hasABottle())
+                || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive());
         });
 
         $this->locations["Chicken House"]->setRequirements(function ($locations, $items) {
             return $items->has('MoonPearl')
-                || ($this->world->config('canOWYBA', false)
-                    && $items->hasABottle()) || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive());
+                || ($this->world->config('canOWYBA', false) && $items->hasABottle())
+                || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive());
         });
 
         $this->locations["Kakariko Well - Top"]->setRequirements(function ($locations, $items) {
             return $items->canBombThings()
                 && ($items->has('MoonPearl')
-                    || ($this->world->config('canOWYBA', false)
-                        && $items->hasABottle()) || ($this->world->config('canBunnyRevive', false)
-                        && $items->canBunnyRevive()));
+                    || ($this->world->config('canOWYBA', false) && $items->hasABottle())
+                    || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive()));
         });
 
         $this->locations["Kakariko Well - Left"]->setRequirements(function ($locations, $items) {
             return $items->has('MoonPearl')
                 || $this->world->config('canSuperBunny', false)
-                || ($this->world->config('canOWYBA', false)
-                    && $items->hasABottle()) || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive());
+                || ($this->world->config('canOWYBA', false) && $items->hasABottle())
+                || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive());
         });
 
         $this->locations["Kakariko Well - Middle"]->setRequirements(function ($locations, $items) {
             return $items->has('MoonPearl')
                 || $this->world->config('canSuperBunny', false)
-                || ($this->world->config('canOWYBA', false)
-                    && $items->hasABottle()) || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive());
+                || ($this->world->config('canOWYBA', false) && $items->hasABottle())
+                || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive());
         });
 
         $this->locations["Kakariko Well - Right"]->setRequirements(function ($locations, $items) {
             return $items->has('MoonPearl')
                 || $this->world->config('canSuperBunny', false)
-                || ($this->world->config('canOWYBA', false)
-                    && $items->hasABottle()) || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive());
+                || ($this->world->config('canOWYBA', false) && $items->hasABottle())
+                || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive());
         });
 
         $this->locations["Kakariko Well - Bottom"]->setRequirements(function ($locations, $items) {
             return $items->has('MoonPearl')
                 || $this->world->config('canSuperBunny', false)
-                || ($this->world->config('canOWYBA', false)
-                    && $items->hasABottle()) || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive());
+                || ($this->world->config('canOWYBA', false) && $items->hasABottle())
+                || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive());
         });
 
         $this->locations["Blind's Hideout - Top"]->setRequirements(function ($locations, $items) {
             return $items->canBombThings()
                 && ($items->has('MoonPearl')
-                    || ($this->world->config('canOWYBA', false)
-                        && $items->hasABottle()) || ($this->world->config('canBunnyRevive', false)
-                        && $items->canBunnyRevive()));
+                    || ($this->world->config('canOWYBA', false) && $items->hasABottle())
+                    || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive()));
         });
 
         $this->locations["Blind's Hideout - Left"]->setRequirements(function ($locations, $items) {
             return $items->has('MoonPearl')
-                || ($this->world->config('canSuperBunny', false)
-                    && $items->has('MagicMirror')) || ($this->world->config('canOWYBA', false)
-                    && $items->hasABottle()) || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive());
+                || ($this->world->config('canSuperBunny', false) && $items->has('MagicMirror'))
+                || ($this->world->config('canOWYBA', false) && $items->hasABottle())
+                || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive());
         });
 
         $this->locations["Blind's Hideout - Right"]->setRequirements(function ($locations, $items) {
             return $items->has('MoonPearl')
-                || ($this->world->config('canSuperBunny', false)
-                    && $items->has('MagicMirror')) || ($this->world->config('canOWYBA', false)
-                    && $items->hasABottle()) || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive());
+                || ($this->world->config('canSuperBunny', false) && $items->has('MagicMirror'))
+                || ($this->world->config('canOWYBA', false) && $items->hasABottle())
+                || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive());
         });
 
         $this->locations["Blind's Hideout - Far Left"]->setRequirements(function ($locations, $items) {
             return $items->has('MoonPearl')
-                || ($this->world->config('canSuperBunny', false)
-                    && $items->has('MagicMirror')) || ($this->world->config('canOWYBA', false)
-                    && $items->hasABottle()) || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive());
+                || ($this->world->config('canSuperBunny', false) && $items->has('MagicMirror'))
+                || ($this->world->config('canOWYBA', false) && $items->hasABottle())
+                || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive());
         });
 
         $this->locations["Blind's Hideout - Far Right"]->setRequirements(function ($locations, $items) {
             return $items->has('MoonPearl')
-                || ($this->world->config('canSuperBunny', false)
-                    && $items->has('MagicMirror')) || ($this->world->config('canOWYBA', false)
-                    && $items->hasABottle()) || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive());
+                || ($this->world->config('canSuperBunny', false) && $items->has('MagicMirror'))
+                || ($this->world->config('canOWYBA', false) && $items->hasABottle())
+                || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive());
         });
 
         $this->locations["Pegasus Rocks"]->setRequirements(function ($locations, $items) {
             return $items->has('PegasusBoots')
                 && ($items->has('MoonPearl')
-                    || ($this->world->config('canOWYBA', false)
-                        && $items->hasABottle()) || ($this->world->config('canBunnyRevive', false)
-                        && $items->canBunnyRevive()));
+                    || ($this->world->config('canOWYBA', false) && $items->hasABottle())
+                    || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive()));
         });
 
         $this->locations["Magic Bat"]->setRequirements(function ($locations, $items) {
             return $items->has('Powder')
                 && ($items->has('MoonPearl')
-                    || ($this->world->config('canOWYBA', false)
-                        && $items->hasABottle()) || ($this->world->config('canBunnyRevive', false)
-                        && $items->canBunnyRevive())) && ($items->has('Hammer')
-                    || (
-                        ($this->world->config('canBootsClip', false)
-                            && $items->has('PegasusBoots')) ||
-                        $this->world->config('canOneFrameClipOW', false)) && ($this->world->config('canFakeFlipper', false)
-                        || $items->has('Flippers')));
+                    || ($this->world->config('canOWYBA', false) && $items->hasABottle())
+                    || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive()))
+                && ($items->has('Hammer')
+                    || (($this->world->config('canBootsClip', false) && $items->has('PegasusBoots'))
+                        || $this->world->config('canOneFrameClipOW', false))
+                    && ($this->world->config('canFakeFlipper', false) || $items->has('Flippers')));
         });
 
         $this->locations["Sick Kid"]->setRequirements(function ($locations, $items) {
@@ -184,34 +162,29 @@ class NorthWest extends Region\Standard\LightWorld\NorthWest
             return $items->has('DefeatAgahnim')
                 && ($items->has('PegasusBoots')
                     && ($items->has('MoonPearl')
-                        || ($this->world->config('canBunnyRevive', false)
-                            && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
-                            && $items->hasABottle())) ||
-                    $this->world->config('canOneFrameClipOW', false)
-                    || ($this->world->config('canMirrorWrap', false)
-                        && $items->has('MagicMirror')));
+                        || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
+                        || ($this->world->config('canOWYBA', false) && $items->hasABottle()))
+                    || $this->world->config('canOneFrameClipOW', false)
+                    || ($this->world->config('canMirrorWrap', false) && $items->has('MagicMirror')));
         });
 
         $this->locations["Graveyard Ledge"]->setRequirements(function ($locations, $items) {
             return ($items->has('MoonPearl')
-                || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
-                    && $items->hasABottle())) &&
-                $items->canBombThings();
+                    || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
+                    || ($this->world->config('canOWYBA', false) && $items->hasABottle()))
+                && $items->canBombThings();
         });
 
         $this->locations["Mushroom"]->setRequirements(function ($locations, $items) {
             return $items->has('MoonPearl')
-                || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
-                    && $items->hasABottle());
+                || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
+                || ($this->world->config('canOWYBA', false) && $items->hasABottle());
         });
 
         $this->locations["Lost Woods Hideout"]->setRequirements(function ($locations, $items) {
             return $items->has('MoonPearl')
-                || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
-                    && $items->hasABottle());
+                || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
+                || ($this->world->config('canOWYBA', false) && $items->hasABottle());
         });
 
         $this->can_enter = function ($locations, $items) {

--- a/app/Region/Inverted/LightWorld/South.php
+++ b/app/Region/Inverted/LightWorld/South.php
@@ -39,202 +39,179 @@ class South extends Region\Standard\LightWorld\South
     {
         $this->shops["20 Rupee Cave"]->setRequirements(function ($locations, $items) {
             return ($items->has('MoonPearl')
-                || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
-                    && $items->hasABottle())) &&
-                $items->canLiftRocks();
+                    || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
+                    || ($this->world->config('canOWYBA', false) && $items->hasABottle()))
+                && $items->canLiftRocks();
         });
 
         $this->shops["50 Rupee Cave"]->setRequirements(function ($locations, $items) {
             return ($items->has('MoonPearl')
-                || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
-                    && $items->hasABottle())) &&
-                $items->canLiftRocks();
+                    || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
+                    || ($this->world->config('canOWYBA', false) && $items->hasABottle()))
+                && $items->canLiftRocks();
         });
 
         $this->shops["Bonk Fairy (Light)"]->setRequirements(function ($locations, $items) {
             return ($items->has('MoonPearl')
-                || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
-                    && $items->hasABottle())) &&
-                $items->has('PegasusBoots');
+                    || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
+                    || ($this->world->config('canOWYBA', false) && $items->hasABottle()))
+                && $items->has('PegasusBoots');
         });
 
         $this->shops["Light Hype Fairy"]->setRequirements(function ($locations, $items) {
             return ($items->has('MoonPearl')
-                || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
-                    && $items->hasABottle())) &&
-                $items->canBombThings();
+                    || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
+                    || ($this->world->config('canOWYBA', false) && $items->hasABottle()))
+                && $items->canBombThings();
         });
 
         $this->shops["Capacity Upgrade"]->setRequirements(function ($locations, $items) {
             return ($items->has('MoonPearl')
-                || ($this->world->config('canOWYBA', false)
-                    && $items->hasABottle())) && (
-                ($this->world->config('canFakeFlipper', false)
-                    || $items->has('Flippers')) || ($this->world->config('canWaterWalk', false)
-                    && $items->has('PegasusBoots'))) || ($this->world->config('canBunnyRevive', false)
-                && $items->canBunnyRevive());
+                    || ($this->world->config('canOWYBA', false) && $items->hasABottle()))
+                && (($this->world->config('canFakeFlipper', false) || $items->has('Flippers'))
+                    || ($this->world->config('canWaterWalk', false) && $items->has('PegasusBoots')))
+                || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive());
         });
 
         $this->locations["Floodgate Chest"]->setRequirements(function ($locations, $items) {
             return ($items->has('MoonPearl')
-                || ($this->world->config('canSuperBunny', false)
-                    && $items->has('MagicMirror')) || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
-                    && $items->hasABottle()));
+                || ($this->world->config('canSuperBunny', false) && $items->has('MagicMirror'))
+                || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
+                || ($this->world->config('canOWYBA', false) && $items->hasABottle()));
         });
 
         $this->locations["Bomb Merchant"]->setRequirements(function ($locations, $items) {
             return ($items->has('MoonPearl')
-                || $this->world->config('canSuperBunny', false)) &&
-                $items->has('Crystal5') && $items->has('Crystal6');
+                    || $this->world->config('canSuperBunny', false))
+                && $items->has('Crystal5') && $items->has('Crystal6');
         });
 
         $this->locations["Aginah's Cave"]->setRequirements(function ($locations, $items) {
             return ($items->has('MoonPearl')
-                || ($this->world->config('canOWYBA', false)
-                    && $items->hasABottle()) || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive())) &&
-                $items->canBombThings();
+                    || ($this->world->config('canOWYBA', false) && $items->hasABottle())
+                    || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive()))
+                && $items->canBombThings();
         });
 
         $this->locations["Mini Moldorm Cave - Far Left"]->setRequirements(function ($locations, $items) {
             return ($items->has('MoonPearl')
-                || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
-                    && $items->hasABottle())) &&
-                $items->canBombThings();
+                    || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
+                    || ($this->world->config('canOWYBA', false) && $items->hasABottle()))
+                && $items->canBombThings();
         });
 
         $this->locations["Mini Moldorm Cave - Left"]->setRequirements(function ($locations, $items) {
             return ($items->has('MoonPearl')
-                || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
-                    && $items->hasABottle())) &&
-                $items->canBombThings();
+                    || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
+                    || ($this->world->config('canOWYBA', false) && $items->hasABottle()))
+                && $items->canBombThings();
         });
 
         $this->locations["Mini Moldorm Cave - Right"]->setRequirements(function ($locations, $items) {
             return ($items->has('MoonPearl')
-                || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
-                    && $items->hasABottle())) &&
-                $items->canBombThings();
+                    || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
+                    || ($this->world->config('canOWYBA', false) && $items->hasABottle()))
+                && $items->canBombThings();
         });
 
         $this->locations["Mini Moldorm Cave - Far Right"]->setRequirements(function ($locations, $items) {
             return ($items->has('MoonPearl')
-                || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
-                    && $items->hasABottle())) &&
-                $items->canBombThings();
+                    || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
+                    || ($this->world->config('canOWYBA', false) && $items->hasABottle()))
+                && $items->canBombThings();
         });
 
         $this->locations["Ice Rod Cave"]->setRequirements(function ($locations, $items) {
             return (($items->has('MoonPearl')
-                || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
-                    && $items->hasABottle())) &&
-                $items->canBombThings()) || ($items->has('BigRedBomb')
-                && $this->world->config('canSuperBunny', false)
-                && $items->has('MagicMirror'));
+                        || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
+                        || ($this->world->config('canOWYBA', false) && $items->hasABottle()))
+                    && $items->canBombThings())
+                || ($items->has('BigRedBomb')
+                    && $this->world->config('canSuperBunny', false) && $items->has('MagicMirror'));
         });
 
         $this->locations["Hobo"]->setRequirements(function ($locations, $items) {
             return ($items->has('MoonPearl')
-                || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
-                    && $items->hasABottle())) && (
-                ($this->world->config('canFakeFlipper', false)
-                    || $items->has('Flippers')) || ($this->world->config('canWaterWalk', false)
-                    && $items->has('PegasusBoots')));
+                    || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
+                    || ($this->world->config('canOWYBA', false) && $items->hasABottle()))
+                && (($this->world->config('canFakeFlipper', false) || $items->has('Flippers'))
+                    || ($this->world->config('canWaterWalk', false) && $items->has('PegasusBoots')));
         });
 
         $this->locations["Bombos Tablet"]->setRequirements(function ($locations, $items) {
             return $items->has('BookOfMudora')
                 && ($items->hasSword(2)
-                    || ($this->world->config('mode.weapons') == 'swordless'
-                        && $items->has('Hammer')));
+                    || ($this->world->config('mode.weapons') == 'swordless' && $items->has('Hammer')));
         });
 
         $this->locations["Cave 45"]->setRequirements(function ($locations, $items) {
             return $items->has('MoonPearl')
-                || ($this->world->config('canSuperBunny', false)
-                    && $items->has('MagicMirror')) || ($this->world->config('canOWYBA', false)
-                    && $items->hasABottle()) || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive());
+                || ($this->world->config('canSuperBunny', false) && $items->has('MagicMirror'))
+                || ($this->world->config('canOWYBA', false) && $items->hasABottle())
+                || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive());
         });
 
         $this->locations["Checkerboard Cave"]->setRequirements(function ($locations, $items) {
             return ($items->has('MoonPearl')
-                || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
-                    && $items->hasABottle()))
+                    || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
+                    || ($this->world->config('canOWYBA', false) && $items->hasABottle()))
                 && $items->canLiftRocks();
         });
 
         $this->locations["Mini Moldorm Cave - NPC"]->setRequirements(function ($locations, $items) {
             return ($items->has('MoonPearl')
-                || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
-                    && $items->hasABottle())) &&
-                $items->canBombThings();
+                    || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
+                    || ($this->world->config('canOWYBA', false) && $items->hasABottle()))
+                && $items->canBombThings();
         });
 
         $this->locations["Library"]->setRequirements(function ($locations, $items) {
             return ($items->has('MoonPearl')
-                || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
-                    && $items->hasABottle()) || ($this->world->config('canSuperBunny', false)
-                    && $items->has('MagicMirror'))) 
+                    || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
+                    || ($this->world->config('canOWYBA', false) && $items->hasABottle())
+                    || ($this->world->config('canSuperBunny', false) && $items->has('MagicMirror')))
                 && $items->has('PegasusBoots');
         });
 
         $this->locations["Maze Race"]->setRequirements(function ($locations, $items) {
             return ($items->has('MoonPearl')
-                && ($items->has('PegasusBoots')
-                    || $items->canBombThings())) ||
-                $this->world->config('canOneFrameClipOW', false);
+                    && ($items->has('PegasusBoots')
+                        || $items->canBombThings()))
+                || $this->world->config('canOneFrameClipOW', false);
         });
 
         $this->locations["Desert Ledge"]->setRequirements(function ($locations, $items) {
             return (($items->has('MoonPearl')
-                || $this->world->config('canDungeonRevive', false) || ($this->world->config('canSuperBunny', false)
-                    && $items->has('MagicMirror')) || ($this->world->config('canOWYBA', false)
-                    && $items->hasABottle())) && $this->world->getRegion('Desert Palace')->canEnter($locations, $items))
-                ||
-                $this->world->config('canOneFrameClipOW', false)
-                || ($this->world->config('canBootsClip', false)
-                    && $items->has('PegasusBoots'));
+                        || $this->world->config('canDungeonRevive', false)
+                        || ($this->world->config('canSuperBunny', false) && $items->has('MagicMirror'))
+                        || ($this->world->config('canOWYBA', false) && $items->hasABottle()))
+                    && $this->world->getRegion('Desert Palace')->canEnter($locations, $items))
+                || $this->world->config('canOneFrameClipOW', false)
+                || ($this->world->config('canBootsClip', false) && $items->has('PegasusBoots'));
         });
 
         $this->locations["Lake Hylia Island"]->setRequirements(function ($locations, $items) {
             return (($items->has('MoonPearl')
-                || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
-                    && $items->hasABottle())) && ($items->has('Flippers')
-                    || ($this->world->config('canBootsClip', false)
-                        && $items->has('PegasusBoots')) || ($this->world->config('canSuperSpeed', false)
-                        && $items->canSpinSpeed()))) 
+                        || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
+                        || ($this->world->config('canOWYBA', false) && $items->hasABottle()))
+                    && ($items->has('Flippers')
+                        || ($this->world->config('canBootsClip', false) && $items->has('PegasusBoots'))
+                        || ($this->world->config('canSuperSpeed', false) && $items->canSpinSpeed())))
                 || $this->world->config('canOneFrameClipOW', false);
         });
 
         $this->locations["Sunken Treasure"]->setRequirements(function ($locations, $items) {
             return $items->has('MoonPearl')
-                || ($this->world->config('canSuperBunny', false)
-                    && $items->has('MagicMirror')) || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive()) || ($this->world->config('canOWYBA', false)
-                    && $items->hasABottle());
+                || ($this->world->config('canSuperBunny', false) && $items->has('MagicMirror'))
+                || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
+                || ($this->world->config('canOWYBA', false) && $items->hasABottle());
         });
 
         $this->locations["Flute Spot"]->setRequirements(function ($locations, $items) {
             return ($items->has('MoonPearl')
-                || ($this->world->config('canOWYBA', false)
-                    && $items->hasABottle()) || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive())) && $items->has('Shovel');
+                    || ($this->world->config('canOWYBA', false) && $items->hasABottle())
+                    || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive()))
+                && $items->has('Shovel');
         });
 
         $this->can_enter = function ($locations, $items) {

--- a/app/Region/Inverted/MiseryMire.php
+++ b/app/Region/Inverted/MiseryMire.php
@@ -22,18 +22,13 @@ class MiseryMire extends Region\Standard\MiseryMire
 
         $this->can_enter = function ($locations, $items) {
             return ($this->world->config('itemPlacement') !== 'basic'
-                || (
-                    ($this->world->config('mode.weapons') === 'swordless'
-                        || $items->hasSword(2))
-                    && $items->hasHealth(12)
-                    && ($items->hasBottle(2)
-                        || $items->hasArmor()))) && (
-                ($locations["Misery Mire Medallion"]->hasItem(Item::get('Bombos', $this->world))
-                    && $items->has('Bombos')) || ($locations["Misery Mire Medallion"]->hasItem(Item::get('Ether', $this->world))
-                    && $items->has('Ether')) || ($locations["Misery Mire Medallion"]->hasItem(Item::get('Quake', $this->world))
-                    && $items->has('Quake'))) && ($this->world->config('mode.weapons') == 'swordless'
-                || $items->hasSword()) && ($items->has('PegasusBoots')
-                || $items->has('Hookshot'))
+                    || (($this->world->config('mode.weapons') === 'swordless' || $items->hasSword(2))
+                        && $items->hasHealth(12) && ($items->hasBottle(2) || $items->hasArmor())))
+                && (($locations["Misery Mire Medallion"]->hasItem(Item::get('Bombos', $this->world)) && $items->has('Bombos'))
+                    || ($locations["Misery Mire Medallion"]->hasItem(Item::get('Ether', $this->world)) && $items->has('Ether'))
+                    || ($locations["Misery Mire Medallion"]->hasItem(Item::get('Quake', $this->world)) && $items->has('Quake')))
+                && ($this->world->config('mode.weapons') == 'swordless' || $items->hasSword())
+                && ($items->has('PegasusBoots') || $items->has('Hookshot'))
                 && $items->canKillMostThings($this->world, 8)
                 && $this->world->getRegion('Mire')->canEnter($locations, $items);
         };

--- a/app/Region/Inverted/PalaceOfDarkness.php
+++ b/app/Region/Inverted/PalaceOfDarkness.php
@@ -21,11 +21,8 @@ class PalaceOfDarkness extends Region\Standard\PalaceOfDarkness
 
         $this->can_enter = function ($locations, $items) {
             return ($this->world->config('itemPlacement') !== 'basic'
-                || (
-                    ($this->world->config('mode.weapons') === 'swordless'
-                        || $items->hasSword())
-                    && $items->hasHealth(7)
-                    && $items->hasABottle()))
+                    || (($this->world->config('mode.weapons') === 'swordless' || $items->hasSword())
+                        && $items->hasHealth(7) && $items->hasABottle()))
                 && ($this->world->getRegion('North East Dark World')->canEnter($locations, $items)
                     || ($this->world->config('canOneFrameClipOW', false)
                         && $this->world->getRegion('West Death Mountain')));

--- a/app/Region/Inverted/SkullWoods.php
+++ b/app/Region/Inverted/SkullWoods.php
@@ -28,24 +28,19 @@ class SkullWoods extends Region\Standard\SkullWoods
         $this->locations["Skull Woods - Boss"]->setRequirements(function ($locations, $items) {
             return $this->canEnter($locations, $items)
                 && $items->has('FireRod')
-                && ($this->world->config('mode.weapons') == 'swordless'
-                    || $items->hasSword())
+                && ($this->world->config('mode.weapons') == 'swordless' || $items->hasSword())
                 && $items->has('KeyD3', 3)
                 && $this->boss->canBeat($items, $locations)
-                && (!$this->world->config('region.wildCompasses', false)
-                    || $items->has('CompassD3')
-                    || $this->locations["Skull Woods - Boss"]->hasItem(Item::get('CompassD3', $this->world))) && (!$this->world->config('region.wildMaps', false)
-                    || $items->has('MapD3')
+                && (!$this->world->config('region.wildCompasses', false) || $items->has('CompassD3')
+                    || $this->locations["Skull Woods - Boss"]->hasItem(Item::get('CompassD3', $this->world)))
+                && (!$this->world->config('region.wildMaps', false) || $items->has('MapD3')
                     || $this->locations["Skull Woods - Boss"]->hasItem(Item::get('MapD3', $this->world)));
         });
 
         $this->can_enter = function ($locations, $items) {
             return ($this->world->config('itemPlacement') !== 'basic'
-                || (
-                    ($this->world->config('mode.weapons') === 'swordless'
-                        || $items->hasSword())
-                    && $items->hasHealth(7)
-                    && $items->hasABottle()))
+                    || (($this->world->config('mode.weapons') === 'swordless' || $items->hasSword())
+                        && $items->hasHealth(7) && $items->hasABottle()))
                 && $this->world->getRegion('North West Dark World')->canEnter($locations, $items);
         };
 

--- a/app/Region/Inverted/SwampPalace.php
+++ b/app/Region/Inverted/SwampPalace.php
@@ -23,10 +23,10 @@ class SwampPalace extends Region\Standard\SwampPalace
         $mire = function ($locations, $items) {
             return $this->world->config('canOneFrameClipUW', false)
                 && (($locations->itemInLocations(Item::get('BigKeyD6', $this->world), [
-                        "Misery Mire - Compass Chest",
-                        "Misery Mire - Big Key Chest",
-                    ]) &&
-                        $items->has('KeyD6', 2)) || $items->has('KeyD6', 3))
+                    "Misery Mire - Compass Chest",
+                    "Misery Mire - Big Key Chest",
+                ]) && $items->has('KeyD6', 2))
+                    || $items->has('KeyD6', 3))
                 && $this->world->getRegion('Misery Mire')->canEnter($locations, $items);
         };
         
@@ -103,10 +103,9 @@ class SwampPalace extends Region\Standard\SwampPalace
                 && ($items->has('Hammer') 
                     || $mire($locations, $items) || $hera($locations, $items))
                 && $this->boss->canBeat($items, $locations)
-                && (!$this->world->config('region.wildCompasses', false)
-                    || $items->has('CompassD2')
-                    || $this->locations["Swamp Palace - Boss"]->hasItem(Item::get('CompassD2', $this->world))) && (!$this->world->config('region.wildMaps', false)
-                    || $items->has('MapD2')
+                && (!$this->world->config('region.wildCompasses', false) || $items->has('CompassD2')
+                    || $this->locations["Swamp Palace - Boss"]->hasItem(Item::get('CompassD2', $this->world)))
+                && (!$this->world->config('region.wildMaps', false) || $items->has('MapD2')
                     || $this->locations["Swamp Palace - Boss"]->hasItem(Item::get('MapD2', $this->world)));
         })->setFillRules(function ($item, $locations, $items) {
             if (
@@ -126,23 +125,18 @@ class SwampPalace extends Region\Standard\SwampPalace
         $this->can_enter = function ($locations, $items) use ($mire) {
             return $items->has('Flippers')
                 && ($this->world->config('itemPlacement') !== 'basic'
-                    || (($this->world->config('mode.weapons') === 'swordless'
-                        || $items->hasSword())
-                    && $items->hasHealth(7)
-                    && $items->hasBottle())) 
+                    || (($this->world->config('mode.weapons') === 'swordless' || $items->hasSword())
+                        && $items->hasHealth(7) && $items->hasBottle())) 
                 && (($items->has('MoonPearl') 
-                    || ($this->world->config('canOWYBA', false)
-                        && $items->hasABottle())
-                    || ($this->world->config('canBunnyRevive', false)
-                        && canBunnyRevive()))
-                    || ($this->world->config('canSuperBunny', false) 
-                        && $items->has('MagicMirror')))
+                    || ($this->world->config('canOWYBA', false) && $items->hasABottle())
+                    || ($this->world->config('canBunnyRevive', false) && canBunnyRevive()))
+                    || ($this->world->config('canSuperBunny', false) && $items->has('MagicMirror')))
                 && ($items->has('MagicMirror')
                     || ($this->world->config('canOneFrameClipUW', false)
                         && $items->has('MoonPearl')
                         && ($items->has('BigKeyP3') || $items->has('BigKeyD6')) && $mire($locations, $items)
                         && $locations["Old Man"]->canAccess($items)
-                        && (($items->has('PegasusBoots') && $this->world->config('canBootsClip', false))
+                        && (($this->world->config('canBootsClip', false) && $items->has('PegasusBoots'))
                             || ($this->world->config('canSuperSpeed', false) && $items->canSpinSpeed())
                             || $this->world->config('canOneFrameClipOW', false))))
                 && $this->world->getRegion('South Light World')->canEnter($locations, $items);

--- a/app/Region/Inverted/ThievesTown.php
+++ b/app/Region/Inverted/ThievesTown.php
@@ -21,11 +21,8 @@ class ThievesTown extends Region\Standard\ThievesTown
 
         $this->can_enter = function ($locations, $items) {
             return ($this->world->config('itemPlacement') !== 'basic'
-                || (
-                    ($this->world->config('mode.weapons') === 'swordless'
-                        || $items->hasSword())
-                    && $items->hasHealth(7)
-                    && $items->hasABottle()))
+                    || (($this->world->config('mode.weapons') === 'swordless' || $items->hasSword())
+                        && $items->hasHealth(7) && $items->hasABottle()))
                 && $this->world->getRegion('North West Dark World')->canEnter($locations, $items);
         };
 

--- a/app/Region/Inverted/TowerOfHera.php
+++ b/app/Region/Inverted/TowerOfHera.php
@@ -22,14 +22,14 @@ class TowerOfHera extends Region\Standard\TowerOfHera
 
         $main = function ($locations, $items) {
             return ($this->world->getRegion('East Death Mountain')->canEnter($locations, $items)
-                && $items->has('MoonPearl')
-                && $items->has('Hammer')) || ($this->world->getRegion('West Death Mountain')->canEnter($locations, $items)
+                    && $items->has('MoonPearl') && $items->has('Hammer'))
+                || ($this->world->getRegion('West Death Mountain')->canEnter($locations, $items)
                     && ((($items->has('MoonPearl')
-                        || ($this->world->config('canOWYBA', false) && $items->hasBottle(2))
-                            || ((($this->world->config('canOWYBA', false) && $items->hasABottle())
-                            || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive()))
-                                && (($this->world->config('canBootsClip', false) && $items->has('PegasusBoots'))
-                                    || $this->world->config('canOneFrameClipOW', false))))
+                                || ($this->world->config('canOWYBA', false) && $items->hasBottle(2))
+                                || ((($this->world->config('canOWYBA', false) && $items->hasABottle())
+                                        || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive()))
+                                    && (($this->world->config('canBootsClip', false) && $items->has('PegasusBoots'))
+                                        || $this->world->config('canOneFrameClipOW', false))))
                             && ($this->world->config('canOneFrameClipOW', false)
                                 || ($this->world->config('canSuperSpeed', false) && $items->canSpinSpeed())
                                 || ($this->world->config('canBootsClip', false) && $items->has('PegasusBoots'))))
@@ -39,47 +39,47 @@ class TowerOfHera extends Region\Standard\TowerOfHera
 
         $mire = function ($locations, $items) {
             return $this->world->config('canOneFrameClipUW', false)
-                && (
-                    ($locations->itemInLocations(Item::get('BigKeyD6', $this->world), [
-                        "Misery Mire - Compass Chest",
-                        "Misery Mire - Big Key Chest",
-                    ]) &&
-                        $items->has('KeyD6', 2)) || $items->has('KeyD6', 3)) &&
-                $this->world->getRegion('Misery Mire')->canEnter($locations, $items);
+                && (($locations->itemInLocations(Item::get('BigKeyD6', $this->world), [
+                    "Misery Mire - Compass Chest",
+                    "Misery Mire - Big Key Chest",
+                ]) && $items->has('KeyD6', 2))
+                    || $items->has('KeyD6', 3))
+                && $this->world->getRegion('Misery Mire')->canEnter($locations, $items);
         };
 
 
         $this->locations["Tower of Hera - Big Key Chest"]->setRequirements(function ($locations, $items) use ($mire) {
             return $items->canLightTorches()
                 && (($items->has('KeyP3')
-                    && ($items->has('MoonPearl') || ($this->world->config('canOWYBA', false)
-                    && $items->hasABottle()) || ($this->world->config('canBunnyRevive', false)
-                    && $items->canBunnyRevive()))) || $mire($locations, $items));
+                    && ($items->has('MoonPearl')
+                        || ($this->world->config('canOWYBA', false) && $items->hasABottle())
+                        || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())))
+                    || $mire($locations, $items));
         })->setAlwaysAllow(function ($item, $items) {
             return $this->world->config('accessibility') !== 'locations' && $item == Item::get('KeyP3', $this->world);
         });
 
         $this->locations["Tower of Hera - Compass Chest"]->setRequirements(function ($locations, $items) use ($main, $mire) {
             return ($main($locations, $items)
-                && $items->has('BigKeyP3')) ||
-                $mire($locations, $items);
+                    && $items->has('BigKeyP3'))
+                || $mire($locations, $items);
         });
 
         $this->locations["Tower of Hera - Big Chest"]->setRequirements(function ($locations, $items) use ($main, $mire) {
             return ($main($locations, $items)
-                && $items->has('BigKeyP3')) || ($mire($locations, $items)
-                && ($items->has('BigKeyP3')
-                    || $items->has('BigKeyD6')));
+                    && $items->has('BigKeyP3'))
+                || ($mire($locations, $items)
+                    && ($items->has('BigKeyP3')
+                        || $items->has('BigKeyD6')));
         });
 
         $this->locations["Tower of Hera - Boss"]->setRequirements(function ($locations, $items) use ($main, $mire){
             return $main($locations, $items)
                 && $this->boss->canBeat($items, $locations)
                 && ($items->has('BigKeyP3') || ($mire($locations, $items) && $items->has('BigKeyD6')))
-                && (!$this->world->config('region.wildCompasses', false)
-                    || $items->has('CompassP3')
-                    || $this->locations["Tower of Hera - Boss"]->hasItem(Item::get('CompassP3', $this->world))) && (!$this->world->config('region.wildMaps', false)
-                    || $items->has('MapP3')
+                && (!$this->world->config('region.wildCompasses', false) || $items->has('CompassP3')
+                    || $this->locations["Tower of Hera - Boss"]->hasItem(Item::get('CompassP3', $this->world)))
+                && (!$this->world->config('region.wildMaps', false) || $items->has('MapP3')
                     || $this->locations["Tower of Hera - Boss"]->hasItem(Item::get('MapP3', $this->world)));
         })->setFillRules(function ($item, $locations, $items) {
             if (

--- a/app/Region/Inverted/TurtleRock.php
+++ b/app/Region/Inverted/TurtleRock.php
@@ -15,7 +15,8 @@ class TurtleRock extends Region\Standard\TurtleRock
         return $items->has('CaneOfSomaria')
             && ($this->enterTop($locations, $items)
                 || ($this->enterMiddle($locations, $items)
-                    && $items->has('KeyD7', 4)) || ($this->enterBottom($locations, $items)
+                    && $items->has('KeyD7', 4))
+                || ($this->enterBottom($locations, $items)
                     && $items->has('Lamp', $this->world->config('item.require.Lamp', 1))
                     && $items->has('KeyD7', 4)));
     }
@@ -24,7 +25,8 @@ class TurtleRock extends Region\Standard\TurtleRock
     {
         return $this->enterMiddle($locations, $items)
             || ($this->enterTop($locations, $items)
-                && $items->has('KeyD7', $this->accountForWastingKeyOnTrinexDoor(2, 3))) || ($this->enterBottom($locations, $items)
+                && $items->has('KeyD7', $this->accountForWastingKeyOnTrinexDoor(2, 3)))
+            || ($this->enterBottom($locations, $items)
                 && $items->has('Lamp', $this->world->config('item.require.Lamp', 1))
                 && $items->has('CaneOfSomaria'));
     }
@@ -32,8 +34,7 @@ class TurtleRock extends Region\Standard\TurtleRock
     protected function canReachBottom($locations, $items)
     {
         return $this->enterBottom($locations, $items)
-            || (
-                ($this->enterTop($locations, $items)
+            || (($this->enterTop($locations, $items)
                     || $this->enterMiddle($locations, $items))
                 && $items->has('Lamp', $this->world->config('item.require.Lamp', 1))
                 && $items->has('CaneOfSomaria')
@@ -52,11 +53,10 @@ class TurtleRock extends Region\Standard\TurtleRock
 
     protected function enterTop($locations, $items)
     {
-        return (($locations["Turtle Rock Medallion"]->hasItem(Item::get('Bombos', $this->world))
-            && $items->has('Bombos')) || ($locations["Turtle Rock Medallion"]->hasItem(Item::get('Ether', $this->world))
-            && $items->has('Ether')) || ($locations["Turtle Rock Medallion"]->hasItem(Item::get('Quake', $this->world))
-            && $items->has('Quake'))) && ($this->world->config('mode.weapons') == 'swordless'
-            || $items->hasSword())
+        return (($locations["Turtle Rock Medallion"]->hasItem(Item::get('Bombos', $this->world)) && $items->has('Bombos'))
+                || ($locations["Turtle Rock Medallion"]->hasItem(Item::get('Ether', $this->world)) && $items->has('Ether'))
+                || ($locations["Turtle Rock Medallion"]->hasItem(Item::get('Quake', $this->world)) && $items->has('Quake')))
+            && ($this->world->config('mode.weapons') == 'swordless' || $items->hasSword())
             && $items->has('CaneOfSomaria')
             && $this->world->getRegion('East Dark World Death Mountain')->canEnter($locations, $items);
     }
@@ -64,10 +64,9 @@ class TurtleRock extends Region\Standard\TurtleRock
     protected function enterMiddle($locations, $items)
     {
         return $this->world->getRegion('East Death Mountain')->canEnter($locations, $items)
-            && $items->has('MagicMirror')
+                && $items->has('MagicMirror')
             || ($this->world->getRegion('East Dark World Death Mountain')->canEnter($locations, $items)
-                && $this->world->config('canSuperSpeed', false)
-                && $items->canSpinSpeed());
+                && $this->world->config('canSuperSpeed', false) && $items->canSpinSpeed());
     }
 
     protected function enterBottom($locations, $items)
@@ -86,9 +85,9 @@ class TurtleRock extends Region\Standard\TurtleRock
     {
         $this->locations["Turtle Rock - Chain Chomps"]->setRequirements(function ($locations, $items) {
             return ($this->enterTop($locations, $items)
-                && $items->has('CaneOfSomaria')
-                && $items->has('KeyD7', $this->accountForWastingKeyOnTrinexDoor(1, 2))) ||
-                $this->enterMiddle($locations, $items);
+                    && $items->has('CaneOfSomaria')
+                    && $items->has('KeyD7', $this->accountForWastingKeyOnTrinexDoor(1, 2)))
+                || $this->enterMiddle($locations, $items);
         });
 
         $this->locations["Turtle Rock - Roller Room - Left"]->setRequirements(function ($locations, $items) {
@@ -125,45 +124,38 @@ class TurtleRock extends Region\Standard\TurtleRock
 
         $this->locations["Turtle Rock - Crystaroller Room"]->setRequirements(function ($locations, $items) {
             return ($items->has('BigKeyD7')
-                && $this->canReachMiddle($locations, $items)) || ($this->enterBottom($locations, $items)
-                && $items->has('Lamp', $this->world->config('item.require.Lamp', 1))
-                && $items->has('CaneOfSomaria'));
+                    && $this->canReachMiddle($locations, $items))
+                || ($this->enterBottom($locations, $items)
+                    && $items->has('Lamp', $this->world->config('item.require.Lamp', 1))
+                    && $items->has('CaneOfSomaria'));
         });
 
         $this->locations["Turtle Rock - Eye Bridge - Bottom Left"]->setRequirements(function ($locations, $items) {
             return $this->canReachBottom($locations, $items)
                 && ($this->world->config('itemPlacement') !== 'basic'
-                    || $items->has('Cape')
-                    || $items->has('CaneOfByrna')
-                    || ($this->world->config('item.overflow.count.Shield', 3) >= 3
-                        && $items->canBlockLasers()));
+                    || $items->has('Cape') || $items->has('CaneOfByrna')
+                    || ($this->world->config('item.overflow.count.Shield', 3) >= 3 && $items->canBlockLasers()));
         });
 
         $this->locations["Turtle Rock - Eye Bridge - Bottom Right"]->setRequirements(function ($locations, $items) {
             return $this->canReachBottom($locations, $items)
                 && ($this->world->config('itemPlacement') !== 'basic'
-                    || $items->has('Cape')
-                    || $items->has('CaneOfByrna')
-                    || ($this->world->config('item.overflow.count.Shield', 3) >= 3
-                        && $items->canBlockLasers()));
+                    || $items->has('Cape') || $items->has('CaneOfByrna')
+                    || ($this->world->config('item.overflow.count.Shield', 3) >= 3 && $items->canBlockLasers()));
         });
 
         $this->locations["Turtle Rock - Eye Bridge - Top Left"]->setRequirements(function ($locations, $items) {
             return $this->canReachBottom($locations, $items)
                 && ($this->world->config('itemPlacement') !== 'basic'
-                    || $items->has('Cape')
-                    || $items->has('CaneOfByrna')
-                    || ($this->world->config('item.overflow.count.Shield', 3) >= 3
-                        && $items->canBlockLasers()));
+                    || $items->has('Cape') || $items->has('CaneOfByrna')
+                    || ($this->world->config('item.overflow.count.Shield', 3) >= 3 && $items->canBlockLasers()));
         });
 
         $this->locations["Turtle Rock - Eye Bridge - Top Right"]->setRequirements(function ($locations, $items) {
             return $this->canReachBottom($locations, $items)
                 && ($this->world->config('itemPlacement') !== 'basic'
-                    || $items->has('Cape')
-                    || $items->has('CaneOfByrna')
-                    || ($this->world->config('item.overflow.count.Shield', 3) >= 3
-                        && $items->canBlockLasers()));
+                    || $items->has('Cape') || $items->has('CaneOfByrna')
+                    || ($this->world->config('item.overflow.count.Shield', 3) >= 3 && $items->canBlockLasers()));
         });
 
         $this->can_complete = function ($locations, $items) {
@@ -176,11 +168,9 @@ class TurtleRock extends Region\Standard\TurtleRock
                 && $items->has('BigKeyD7')
                 && $items->has('CaneOfSomaria')
                 && $this->boss->canBeat($items, $locations)
-                && (!$this->world->config('region.wildCompasses', false)
-                    || $items->has('CompassD7')
+                && (!$this->world->config('region.wildCompasses', false) || $items->has('CompassD7')
                     || $this->locations["Turtle Rock - Boss"]->hasItem(Item::get('CompassD7', $this->world)))
-                && (!$this->world->config('region.wildMaps', false)
-                    || $items->has('MapD7')
+                && (!$this->world->config('region.wildMaps', false) || $items->has('MapD7')
                     || $this->locations["Turtle Rock - Boss"]->hasItem(Item::get('MapD7', $this->world)));
         })->setFillRules(function ($item, $locations, $items) {
             if (
@@ -199,14 +189,11 @@ class TurtleRock extends Region\Standard\TurtleRock
 
         $this->can_enter = function ($locations, $items) {
             return ($this->world->config('itemPlacement') !== 'basic'
-                || (
-                    ($this->world->config('mode.weapons') === 'swordless'
-                        || $items->hasSword(2))
-                    && $items->hasHealth(12)
-                    && ($items->hasBottle(2)
-                        || $items->hasArmor()))) && ($this->enterTop($locations, $items)
-                || $this->enterMiddle($locations, $items)
-                || $this->enterBottom($locations, $items));
+                    || (($this->world->config('mode.weapons') === 'swordless' || $items->hasSword(2))
+                        && $items->hasHealth(12) && ($items->hasBottle(2) || $items->hasArmor())))
+                && ($this->enterTop($locations, $items)
+                    || $this->enterMiddle($locations, $items)
+                    || $this->enterBottom($locations, $items));
         };
 
         $this->prize_location->setRequirements($this->can_complete);

--- a/app/Region/Standard/DarkWorld/DeathMountain/West.php
+++ b/app/Region/Standard/DarkWorld/DeathMountain/West.php
@@ -48,14 +48,14 @@ class West extends Region
         $this->shops["Dark Death Mountain Fairy"]->setRequirements(function ($locations, $items) {
             return $items->has('MoonPearl')
                 || ($this->world->config('canOWYBA', false) && $items->hasABottle()
-                    && (($items->has('PegasusBoots') && $this->world->config('canBootsClip', false))
+                    && (($this->world->config('canBootsClip', false) && $items->has('PegasusBoots'))
                         || $this->world->config('canOneFrameClipOW', false)));
         });
 
         $this->locations["Spike Cave"]->setRequirements(function ($locations, $items) {
             return ($items->has('MoonPearl')
                     || ($this->world->config('canOWYBA', false) && $items->hasABottle()
-                        && (($items->has('PegasusBoots') && $this->world->config('canBootsClip', false))
+                        && (($this->world->config('canBootsClip', false) && $items->has('PegasusBoots'))
                             || $this->world->config('canOneFrameClipOW', false))
                         && (($items->has('Cape') && $items->canExtendMagic(3))
                             || ((!$this->world->config('region.cantTakeDamage', false) || $items->canExtendMagic(3))
@@ -67,7 +67,7 @@ class West extends Region
 
         $this->can_enter = function ($locations, $items) {
             return ($items->has('RescueZelda') 
-            && $this->world->getRegion('West Death Mountain')->canEnter($locations, $items));
+                && $this->world->getRegion('West Death Mountain')->canEnter($locations, $items));
         };
 
         return $this;

--- a/app/Region/Standard/DarkWorld/NorthEast.php
+++ b/app/Region/Standard/DarkWorld/NorthEast.php
@@ -163,9 +163,9 @@ class NorthEast extends Region
                         && (($this->world->config('canBootsClip', false) && $items->has('PegasusBoots'))
                             || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
                             || ($this->world->config('canSuperSpeed', false) && $items->canSpinSpeed())
-                            || ($items->has('MoonPearl') && $this->world->config('canFakeFlipper', false))))
+                            || ($this->world->config('canFakeFlipper', false) && $items->has('MoonPearl'))))
                     || $items->has('DefeatAgahnim')
-                    || ($items->has('MagicMirror') && $this->world->config('canMirrorWrap', false)
+                    || ($this->world->config('canMirrorWrap', false) && $items->has('MagicMirror')
                         && $this->world->config('canBunnyRevive', false) && $items->canBunnyRevive()
                         && (($this->world->config('canSuperSpeed', false) && $items->canSpinSpeed())
                             || ($this->world->config('canBootsClip', false) && $items->has('PegasusBoots'))
@@ -221,8 +221,11 @@ class NorthEast extends Region
                     ($this->world->config('mode.weapons') == 'swordless' && $items->has('Hammer')
                         && ($items->has('Lamp', $this->world->config('item.require.Lamp', 1)) || (
                             $items->has('FireRod') && $items->canExtendMagic(1))))
-                    || (!$this->world->config('region.requireBetterSword', false) && ($items->hasSword(2) && ($items->has('Lamp', $this->world->config('item.require.Lamp', 1)) || ($items->has('FireRod') && $items->canExtendMagic(3)))))
-                    || ($items->hasSword(3) && ($items->has('Lamp', $this->world->config('item.require.Lamp', 1)) || ($items->has('FireRod') && $items->canExtendMagic(2)))));
+                    || (!$this->world->config('region.requireBetterSword', false)
+                        && ($items->hasSword(2) && ($items->has('Lamp', $this->world->config('item.require.Lamp', 1))
+                            || ($items->has('FireRod') && $items->canExtendMagic(3)))))
+                    || ($items->hasSword(3) && ($items->has('Lamp', $this->world->config('item.require.Lamp', 1))
+                        || ($items->has('FireRod') && $items->canExtendMagic(2)))));
         });
 
         return $this;

--- a/app/Region/Standard/DarkWorld/South.php
+++ b/app/Region/Standard/DarkWorld/South.php
@@ -96,7 +96,7 @@ class South extends Region
             return $items->has('MoonPearl')
                 || ($this->world->config('canOWYBA', false) && $items->hasABottle())
                 || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())
-                || ($items->has('MagicMirror') && $this->world->config('canMirrorWrap', false));
+                || ($this->world->config('canMirrorWrap', false) && $items->has('MagicMirror'));
         });
 
         $this->locations["Digging Game"]->setRequirements(function ($locations, $items) {
@@ -113,7 +113,7 @@ class South extends Region
         });
 
         $this->shops["Dark Lake Hylia Ledge Fairy"]->setRequirements(function ($locations, $items) {
-            return ($items->canBombThings() || ($items->has('PegasusBoots') && $this->world->config('canBootsClip', false)))
+            return ($items->canBombThings() || ($this->world->config('canBootsClip', false) && $items->has('PegasusBoots')))
                 && ($items->has('Flippers')
                     || ($this->world->getRegion('North West Dark World')->canEnter($locations, $items)
                         && $this->world->config('canFakeFlipper', false) && (!$this->world->config('region.cantTakeDamage', false)))

--- a/app/Region/Standard/DesertPalace.php
+++ b/app/Region/Standard/DesertPalace.php
@@ -101,8 +101,10 @@ class DesertPalace extends Region
                 && $items->canLightTorches()
                 && $items->has('BigKeyP2') && $items->has('KeyP2')
                 && $this->boss->canBeat($items, $locations)
-                && (!$this->world->config('region.wildCompasses', false) || $items->has('CompassP2') || $this->locations["Desert Palace - Boss"]->hasItem(Item::get('CompassP2', $this->world)))
-                && (!$this->world->config('region.wildMaps', false) || $items->has('MapP2') || $this->locations["Desert Palace - Boss"]->hasItem(Item::get('MapP2', $this->world)));
+                && (!$this->world->config('region.wildCompasses', false) || $items->has('CompassP2')
+                    || $this->locations["Desert Palace - Boss"]->hasItem(Item::get('CompassP2', $this->world)))
+                && (!$this->world->config('region.wildMaps', false) || $items->has('MapP2')
+                    || $this->locations["Desert Palace - Boss"]->hasItem(Item::get('MapP2', $this->world)));
         })->setFillRules(function ($item, $locations, $items) {
             if (
                 !$this->world->config('region.bossNormalLocation', true)

--- a/app/Region/Standard/EasternPalace.php
+++ b/app/Region/Standard/EasternPalace.php
@@ -86,8 +86,10 @@ class EasternPalace extends Region
                     || ($this->world->config('itemPlacement') === 'advanced' && $items->has('FireRod')))
                 && $items->has('BigKeyP1')
                 && $this->boss->canBeat($items, $locations)
-                && (!$this->world->config('region.wildCompasses', false) || $items->has('CompassP1') || $this->locations["Eastern Palace - Boss"]->hasItem(Item::get('CompassP1', $this->world)))
-                && (!$this->world->config('region.wildMaps', false) || $items->has('MapP1') || $this->locations["Eastern Palace - Boss"]->hasItem(Item::get('MapP1', $this->world)));
+                && (!$this->world->config('region.wildCompasses', false) || $items->has('CompassP1')
+                    || $this->locations["Eastern Palace - Boss"]->hasItem(Item::get('CompassP1', $this->world)))
+                && (!$this->world->config('region.wildMaps', false) || $items->has('MapP1')
+                    || $this->locations["Eastern Palace - Boss"]->hasItem(Item::get('MapP1', $this->world)));
         })->setFillRules(function ($item, $locations, $items) {
             if (
                 !$this->world->config('region.bossNormalLocation', true)

--- a/app/Region/Standard/GanonsTower.php
+++ b/app/Region/Standard/GanonsTower.php
@@ -263,7 +263,9 @@ class GanonsTower extends Region
         });
 
         $this->locations["Ganon's Tower - Map Chest"]->setRequirements(function ($locations, $items) {
-            return $items->has('Hammer') && ($items->has('Hookshot') || ($this->world->config('itemPlacement') !== 'basic' && $items->has('PegasusBoots')))
+            return $items->has('Hammer')
+                && ($items->has('Hookshot')
+                    || ($this->world->config('itemPlacement') !== 'basic' && $items->has('PegasusBoots')))
                 && (in_array($locations["Ganon's Tower - Map Chest"]->getItem(), [Item::get('BigKeyA2', $this->world), Item::get('KeyA2', $this->world)])
                     ? $items->has('KeyA2', 3) : $items->has('KeyA2', 4));
         })->setAlwaysAllow(function ($item, $items) {
@@ -395,7 +397,8 @@ class GanonsTower extends Region
         $this->can_enter = function ($locations, $items) {
             return $items->has('RescueZelda')
                 && ($this->world->config('itemPlacement') !== 'basic'
-                    || (($this->world->config('mode.weapons') === 'swordless' || $items->hasSword(2)) && $items->hasHealth(12) && ($items->hasBottle(2) || $items->hasArmor())))
+                    || (($this->world->config('mode.weapons') === 'swordless' || $items->hasSword(2))
+                        && $items->hasHealth(12) && ($items->hasBottle(2) || $items->hasArmor())))
                 && ((($items->has('MoonPearl') || ($this->world->config('canOWYBA', false) && $items->hasABottle()))
                     && (((($items->has('Crystal1')
                         + $items->has('Crystal2')

--- a/app/Region/Standard/HyruleCastleTower.php
+++ b/app/Region/Standard/HyruleCastleTower.php
@@ -61,7 +61,8 @@ class HyruleCastleTower extends Region
 
         $this->can_complete = function ($locations, $items) {
             return $this->canEnter($locations, $items) && $items->has('KeyA1', 2)
-                && $items->has('Lamp', $this->world->config('item.require.Lamp', 1)) && ($items->hasSword()
+                && $items->has('Lamp', $this->world->config('item.require.Lamp', 1))
+                && ($items->hasSword()
                     || ($this->world->config('mode.weapons') == 'swordless' && ($items->has('Hammer') || $items->has('BugCatchingNet'))));
         };
 

--- a/app/Region/Standard/IcePalace.php
+++ b/app/Region/Standard/IcePalace.php
@@ -106,11 +106,13 @@ class IcePalace extends Region
                 && $items->has('Hammer') && $items->canLiftRocks()
                 && $this->boss->canBeat($items, $locations)
                 && $items->has('BigKeyD5') && (
-                    ($this->world->config('itemPlacement') !== 'basic' && ($items->has('CaneOfSomaria') && $items->has('KeyD5')
-                        || $items->has('KeyD5', 2)))
+                    ($this->world->config('itemPlacement') !== 'basic'
+                        && ($items->has('CaneOfSomaria') && $items->has('KeyD5') || $items->has('KeyD5', 2)))
                     || ($this->world->config('itemPlacement') === 'basic' && $items->has('KeyD5', 2)))
-                && (!$this->world->config('region.wildCompasses', false) || $items->has('CompassD5') || $this->locations["Ice Palace - Boss"]->hasItem(Item::get('CompassD5', $this->world)))
-                && (!$this->world->config('region.wildMaps', false) || $items->has('MapD5') || $this->locations["Ice Palace - Boss"]->hasItem(Item::get('MapD5', $this->world)));
+                && (!$this->world->config('region.wildCompasses', false) || $items->has('CompassD5')
+                    || $this->locations["Ice Palace - Boss"]->hasItem(Item::get('CompassD5', $this->world)))
+                && (!$this->world->config('region.wildMaps', false) || $items->has('MapD5')
+                    || $this->locations["Ice Palace - Boss"]->hasItem(Item::get('MapD5', $this->world)));
         })->setFillRules(function ($item, $locations, $items) {
             if (
                 !$this->world->config('region.bossNormalLocation', true)
@@ -128,14 +130,15 @@ class IcePalace extends Region
         $this->can_enter = function ($locations, $items) {
             return $items->has('RescueZelda')
                 && ($this->world->config('itemPlacement') !== 'basic'
-                    || (($this->world->config('mode.weapons') === 'swordless' || $items->hasSword(2)) && $items->hasHealth(12) && ($items->hasBottle(2) || $items->hasArmor())))
+                    || (($this->world->config('mode.weapons') === 'swordless' || $items->hasSword(2))
+                        && $items->hasHealth(12) && ($items->hasBottle(2) || $items->hasArmor())))
                 && ($items->canMeltThings($this->world) || $this->world->config('canOneFrameClipUW', false))
                 && ((($items->has('MoonPearl') || $this->world->config('canDungeonRevive', false))
-                    && ($items->has('Flippers') || $this->world->config('canFakeFlipper', false))
+                    && ($this->world->config('canFakeFlipper', false) || $items->has('Flippers'))
                     && $items->canLiftDarkRocks())
                     || ($this->world->getRegion('South Dark World')->canEnter($locations, $items)
                         && ((($items->has('MoonPearl')
-                            || ($items->hasABottle() && $this->world->config('canOWYBA', false))
+                            || ($this->world->config('canOWYBA', false) && $items->hasABottle())
                             || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive()))
                         && (($this->world->config('canMirrorWrap', false) && $items->has('MagicMirror')
                             && (($this->world->config('canBootsClip', false) && $items->has('PegasusBoots'))

--- a/app/Region/Standard/LightWorld/DeathMountain/East.php
+++ b/app/Region/Standard/LightWorld/DeathMountain/East.php
@@ -91,8 +91,8 @@ class East extends Region
                 && ($this->world->config('canOneFrameClipOW', false)
                     || ($this->world->config('canBootsClip', false) && $items->has('PegasusBoots'))
                     || ($this->world->config('canSuperSpeed', false) && $items->canSpinSpeed())
-                    || (((($this->world->config('canMirrorClip', false) || $this->world->config('canMirrorWrap', false))
-                        && $items->has('MagicMirror')) || $items->has('Hookshot'))
+                    || (((($this->world->config('canMirrorClip', false) || $this->world->config('canMirrorWrap', false)) && $items->has('MagicMirror'))
+                            || $items->has('Hookshot'))
                         && $this->world->getRegion('West Death Mountain')->canEnter($locations, $items))
                     || ($items->has('Hammer') && $this->world->getRegion('Tower of Hera')->canEnter($locations, $items)));
         };

--- a/app/Region/Standard/LightWorld/NorthEast.php
+++ b/app/Region/Standard/LightWorld/NorthEast.php
@@ -85,13 +85,13 @@ class NorthEast extends Region
         $this->locations["Waterfall Fairy - Left"]->setRequirements(function ($locations, $items) {
             return $items->has('Flippers')
                 || ($this->world->config('canWaterWalk', false) && ($items->has('PegasusBoots')
-                    || ($items->has('MoonPearl') && $this->world->config('canFakeFlipper', false))));
+                    || ($this->world->config('canFakeFlipper', false) && $items->has('MoonPearl'))));
         });
 
         $this->locations["Waterfall Fairy - Right"]->setRequirements(function ($locations, $items) {
             return $items->has('Flippers')
                 || ($this->world->config('canWaterWalk', false) && ($items->has('PegasusBoots')
-                    || ($items->has('MoonPearl') && $this->world->config('canFakeFlipper', false))));
+                    || ($this->world->config('canFakeFlipper', false) && $items->has('MoonPearl'))));
         });
 
         $this->can_enter = function ($locations, $items) {

--- a/app/Region/Standard/LightWorld/NorthWest.php
+++ b/app/Region/Standard/LightWorld/NorthWest.php
@@ -97,7 +97,8 @@ class NorthWest extends Region
                     || $this->world->config('canOneFrameClipOW', false)
                     || ($this->world->config('canSuperSpeed', false) && $items->canSpinSpeed())
                     || ($items->has('MagicMirror') && $this->world->getRegion('North West Dark World')->canEnter($locations, $items)
-                        && ($items->has('MoonPearl') || ($items->hasABottle() && $this->world->config('canOWYBA', false))
+                        && ($items->has('MoonPearl')
+                            || ($this->world->config('canOWYBA', false) && $items->hasABottle())
                             || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive()))));
         });
 
@@ -110,14 +111,15 @@ class NorthWest extends Region
                 && ($items->has('Hammer')
                     || ((($this->world->config('canBootsClip', false) && $items->has('PegasusBoots'))
                         || $this->world->config('canOneFrameClipOW', false))
-                        && ($items->has('Flippers') || $this->world->config('canFakeFlipper', false)))
+                        && ($this->world->config('canFakeFlipper', false) || $items->has('Flippers')))
                     || ($items->has('MagicMirror')
                         && (($this->world->config('canMirrorWrap', false) && $this->world->getRegion('North West Dark World')->canEnter($locations, $items))
-                            || (($items->has('MoonPearl') || ($items->hasABottle() && $this->world->config('canOWYBA', false))
+                            || (($items->has('MoonPearl')
+                                || ($this->world->config('canOWYBA', false) && $items->hasABottle())
                                 || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive()))
                                 && (($items->canLiftDarkRocks() && $this->world->getRegion('North West Dark World')->canEnter($locations, $items))
                                     || ($this->world->config('canSuperSpeed', false) && $items->canSpinSpeed()
-                                        && ($items->has('Flippers') || $this->world->config('canFakeFlipper', false))
+                                        && ($this->world->config('canFakeFlipper', false) || $items->has('Flippers'))
                                         && $this->world->getRegion('North East Dark World')->canEnter($locations, $items)))))));
         });
 
@@ -134,7 +136,8 @@ class NorthWest extends Region
                 || ($this->world->config('canSuperSpeed', false) && $items->canSpinSpeed())
                 || $this->world->config('canOneFrameClipOW', false)
                 || ($items->has('MagicMirror') && $this->world->getRegion('North West Dark World')->canEnter($locations, $items)
-                    && ($items->has('MoonPearl') || ($items->hasABottle() && $this->world->config('canOWYBA', false))
+                    && ($items->has('MoonPearl')
+                        || ($this->world->config('canOWYBA', false) && $items->hasABottle())
                         || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())));
         });
 

--- a/app/Region/Standard/MiseryMire.php
+++ b/app/Region/Standard/MiseryMire.php
@@ -107,8 +107,10 @@ class MiseryMire extends Region
                 && $items->has('CaneOfSomaria') && $items->has('Lamp', $this->world->config('item.require.Lamp', 1))
                 && $items->has('BigKeyD6')
                 && $this->boss->canBeat($items, $locations)
-                && (!$this->world->config('region.wildCompasses', false) || $items->has('CompassD6') || $this->locations["Misery Mire - Boss"]->hasItem(Item::get('CompassD6', $this->world)))
-                && (!$this->world->config('region.wildMaps', false) || $items->has('MapD6') || $this->locations["Misery Mire - Boss"]->hasItem(Item::get('MapD6', $this->world)));
+                && (!$this->world->config('region.wildCompasses', false) || $items->has('CompassD6')
+                    || $this->locations["Misery Mire - Boss"]->hasItem(Item::get('CompassD6', $this->world)))
+                && (!$this->world->config('region.wildMaps', false) || $items->has('MapD6')
+                    || $this->locations["Misery Mire - Boss"]->hasItem(Item::get('MapD6', $this->world)));
         })->setFillRules(function ($item, $locations, $items) {
             if (
                 !$this->world->config('region.bossNormalLocation', true)
@@ -127,15 +129,18 @@ class MiseryMire extends Region
         $this->can_enter = function ($locations, $items) {
             return $items->has('RescueZelda')
                 && ($this->world->config('itemPlacement') !== 'basic'
-                    || (($this->world->config('mode.weapons') === 'swordless' || $items->hasSword(2)) && $items->hasHealth(12) && ($items->hasBottle(2) || $items->hasArmor())))
+                    || (($this->world->config('mode.weapons') === 'swordless' || $items->hasSword(2))
+                        && $items->hasHealth(12) && ($items->hasBottle(2) || $items->hasArmor())))
                 && ((($locations["Misery Mire Medallion"]->hasItem(Item::get('Bombos', $this->world)) && $items->has('Bombos'))
                     || ($locations["Misery Mire Medallion"]->hasItem(Item::get('Ether', $this->world)) && $items->has('Ether'))
                     || ($locations["Misery Mire Medallion"]->hasItem(Item::get('Quake', $this->world)) && $items->has('Quake')))
-                    && ($this->world->config('mode.weapons') == 'swordless' || $items->hasSword()))
+                && ($this->world->config('mode.weapons') == 'swordless' || $items->hasSword()))
                 && ($items->has('MoonPearl')
                     || ($items->hasABottle()
-                        && (($items->has('BugCatchingNet') && $this->world->config('canBunnyRevive', false)
-                            && (($items->canLiftDarkRocks() && ($items->canFly($this->world) || ($this->world->config('canBootsClip', false) && $items->has('PegasusBoots'))))
+                        && (($this->world->config('canBunnyRevive', false) && $items->has('BugCatchingNet')
+                            && (($items->canLiftDarkRocks()
+                                && ($items->canFly($this->world)
+                                    || ($this->world->config('canBootsClip', false) && $items->has('PegasusBoots'))))
                                 || ($this->world->config('canOWYBA', false) && $items->has('MagicMirror'))
                                 || $this->world->config('canOneFrameClipOW', false)))
                             || ($this->world->config('canOWYBA', false)

--- a/app/Region/Standard/PalaceOfDarkness.php
+++ b/app/Region/Standard/PalaceOfDarkness.php
@@ -84,7 +84,8 @@ class PalaceOfDarkness extends Region
                 return $items->has('KeyD1');
             }
 
-            return ((($items->has('Hammer') && $items->canShootArrows($this->world) && $items->has('Lamp', $this->world->config('item.require.Lamp', 1))) || $this->world->config('region.wildKeys', false)) ? $items->has('KeyD1', 6) : $items->has('KeyD1', 5));
+            return ((($items->has('Hammer') && $items->canShootArrows($this->world) && $items->has('Lamp', $this->world->config('item.require.Lamp', 1)))
+                || $this->world->config('region.wildKeys', false)) ? $items->has('KeyD1', 6) : $items->has('KeyD1', 5));
         })->setAlwaysAllow(function ($item, $items) {
             return $this->world->config('accessibility') !== 'locations' && $item == Item::get('KeyD1', $this->world) && $items->has('KeyD1', 5);
         })->setFillRules(function ($item, $locations, $items) {
@@ -98,21 +99,25 @@ class PalaceOfDarkness extends Region
 
         $this->locations["Palace of Darkness - Big Chest"]->setRequirements(function ($locations, $items) {
             return $items->has('Lamp', $this->world->config('item.require.Lamp', 1)) && $items->has('BigKeyD1')
-                && ((($items->has('Hammer') && $items->canShootArrows($this->world)) || $this->world->config('region.wildKeys', false)) ? $items->has('KeyD1', 6) : $items->has('KeyD1', 5));
+                && ((($items->has('Hammer') && $items->canShootArrows($this->world))
+                    || $this->world->config('region.wildKeys', false)) ? $items->has('KeyD1', 6) : $items->has('KeyD1', 5));
         })->setFillRules(function ($item, $locations, $items) {
             return $item != Item::get('KeyD1', $this->world);
         });
 
         $this->locations["Palace of Darkness - Compass Chest"]->setRequirements(function ($locations, $items) {
-            return (($items->has('Hammer') && $items->canShootArrows($this->world) && $items->has('Lamp', $this->world->config('item.require.Lamp', 1))) || $this->world->config('region.wildKeys', false)) ? $items->has('KeyD1', 4) : $items->has('KeyD1', 3);
+            return (($items->has('Hammer') && $items->canShootArrows($this->world) && $items->has('Lamp', $this->world->config('item.require.Lamp', 1)))
+                || $this->world->config('region.wildKeys', false)) ? $items->has('KeyD1', 4) : $items->has('KeyD1', 3);
         });
 
         $this->locations["Palace of Darkness - Harmless Hellway"]->setRequirements(function ($locations, $items) {
             if ($locations["Palace of Darkness - Harmless Hellway"]->hasItem(Item::get('KeyD1', $this->world))) {
-                return (($items->has('Hammer') && $items->canShootArrows($this->world) && $items->has('Lamp', $this->world->config('item.require.Lamp', 1))) || $this->world->config('region.wildKeys', false)) ? $items->has('KeyD1', 4) : $items->has('KeyD1', 3);
+                return (($items->has('Hammer') && $items->canShootArrows($this->world) && $items->has('Lamp', $this->world->config('item.require.Lamp', 1)))
+                    || $this->world->config('region.wildKeys', false)) ? $items->has('KeyD1', 4) : $items->has('KeyD1', 3);
             }
 
-            return ((($items->has('Hammer') && $items->canShootArrows($this->world) && $items->has('Lamp', $this->world->config('item.require.Lamp', 1))) || $this->world->config('region.wildKeys', false)) ? $items->has('KeyD1', 6) : $items->has('KeyD1', 5));
+            return ((($items->has('Hammer') && $items->canShootArrows($this->world) && $items->has('Lamp', $this->world->config('item.require.Lamp', 1)))
+                || $this->world->config('region.wildKeys', false)) ? $items->has('KeyD1', 6) : $items->has('KeyD1', 5));
         })->setAlwaysAllow(function ($item, $items) {
             return $this->world->config('accessibility') !== 'locations' && $item == Item::get('KeyD1', $this->world) && $items->has('KeyD1', 5);
         })->setFillRules(function ($item, $locations, $items) {
@@ -127,13 +132,15 @@ class PalaceOfDarkness extends Region
         $this->locations["Palace of Darkness - Dark Basement - Left"]->setRequirements(function ($locations, $items) {
             return ($items->has('Lamp', $this->world->config('item.require.Lamp', 1))
                 || ($this->world->config('itemPlacement') === 'advanced' && $items->has('FireRod')))
-                && ((($items->has('Hammer') && $items->canShootArrows($this->world) && $items->has('Lamp', $this->world->config('item.require.Lamp', 1))) || $this->world->config('region.wildKeys', false)) ? $items->has('KeyD1', 4) : $items->has('KeyD1', 3));
+                && ((($items->has('Hammer') && $items->canShootArrows($this->world) && $items->has('Lamp', $this->world->config('item.require.Lamp', 1)))
+                    || $this->world->config('region.wildKeys', false)) ? $items->has('KeyD1', 4) : $items->has('KeyD1', 3));
         });
 
         $this->locations["Palace of Darkness - Dark Basement - Right"]->setRequirements(function ($locations, $items) {
             return ($items->has('Lamp', $this->world->config('item.require.Lamp', 1))
                 || ($this->world->config('itemPlacement') === 'advanced' && $items->has('FireRod')))
-                && ((($items->has('Hammer') && $items->canShootArrows($this->world) && $items->has('Lamp', $this->world->config('item.require.Lamp', 1))) || $this->world->config('region.wildKeys', false)) ? $items->has('KeyD1', 4) : $items->has('KeyD1', 3));
+                && ((($items->has('Hammer') && $items->canShootArrows($this->world) && $items->has('Lamp', $this->world->config('item.require.Lamp', 1)))
+                    || $this->world->config('region.wildKeys', false)) ? $items->has('KeyD1', 4) : $items->has('KeyD1', 3));
         });
 
         $this->locations["Palace of Darkness - Map Chest"]->setRequirements(function ($locations, $items) {
@@ -141,13 +148,15 @@ class PalaceOfDarkness extends Region
         });
 
         $this->locations["Palace of Darkness - Dark Maze - Top"]->setRequirements(function ($locations, $items) {
-            return $items->has('Lamp', $this->world->config('item.require.Lamp', 1)) && ((($items->has('Hammer') && $items->canShootArrows($this->world)) || $this->world->config('region.wildKeys', false)) ? $items->has('KeyD1', 6) : $items->has('KeyD1', 5));
+            return $items->has('Lamp', $this->world->config('item.require.Lamp', 1)) && ((($items->has('Hammer') && $items->canShootArrows($this->world))
+                || $this->world->config('region.wildKeys', false)) ? $items->has('KeyD1', 6) : $items->has('KeyD1', 5));
         })->setFillRules(function ($item, $locations, $items) {
             return $item != Item::get('KeyD1', $this->world);
         });
 
         $this->locations["Palace of Darkness - Dark Maze - Bottom"]->setRequirements(function ($locations, $items) {
-            return $items->has('Lamp', $this->world->config('item.require.Lamp', 1)) && ((($items->has('Hammer') && $items->canShootArrows($this->world)) || $this->world->config('region.wildKeys', false)) ? $items->has('KeyD1', 6) : $items->has('KeyD1', 5));
+            return $items->has('Lamp', $this->world->config('item.require.Lamp', 1)) && ((($items->has('Hammer') && $items->canShootArrows($this->world))
+                || $this->world->config('region.wildKeys', false)) ? $items->has('KeyD1', 6) : $items->has('KeyD1', 5));
         })->setFillRules(function ($item, $locations, $items) {
             return $item != Item::get('KeyD1', $this->world);
         });
@@ -161,8 +170,10 @@ class PalaceOfDarkness extends Region
                 && $this->boss->canBeat($items, $locations)
                 && $items->has('Hammer') && $items->has('Lamp', $this->world->config('item.require.Lamp', 1)) && $items->canShootArrows($this->world)
                 && $items->has('BigKeyD1') && $items->has('KeyD1', 6)
-                && (!$this->world->config('region.wildCompasses', false) || $items->has('CompassD1') || $this->locations["Palace of Darkness - Boss"]->hasItem(Item::get('CompassD1', $this->world)))
-                && (!$this->world->config('region.wildMaps', false) || $items->has('MapD1') || $this->locations["Palace of Darkness - Boss"]->hasItem(Item::get('MapD1', $this->world)));
+                && (!$this->world->config('region.wildCompasses', false) || $items->has('CompassD1')
+                    || $this->locations["Palace of Darkness - Boss"]->hasItem(Item::get('CompassD1', $this->world)))
+                && (!$this->world->config('region.wildMaps', false) || $items->has('MapD1')
+                    || $this->locations["Palace of Darkness - Boss"]->hasItem(Item::get('MapD1', $this->world)));
         })->setFillRules(function ($item, $locations, $items) {
             if (
                 !$this->world->config('region.bossNormalLocation', true)

--- a/app/Region/Standard/SkullWoods.php
+++ b/app/Region/Standard/SkullWoods.php
@@ -127,8 +127,10 @@ class SkullWoods extends Region
                 && ($this->world->config('mode.weapons') == 'swordless' || $items->hasSword())
                 && $items->has('KeyD3', 3)
                 && $this->boss->canBeat($items, $locations)
-                && (!$this->world->config('region.wildCompasses', false) || $items->has('CompassD3') || $this->locations["Skull Woods - Boss"]->hasItem(Item::get('CompassD3', $this->world)))
-                && (!$this->world->config('region.wildMaps', false) || $items->has('MapD3') || $this->locations["Skull Woods - Boss"]->hasItem(Item::get('MapD3', $this->world)));
+                && (!$this->world->config('region.wildCompasses', false) || $items->has('CompassD3')
+                    || $this->locations["Skull Woods - Boss"]->hasItem(Item::get('CompassD3', $this->world)))
+                && (!$this->world->config('region.wildMaps', false) || $items->has('MapD3')
+                    || $this->locations["Skull Woods - Boss"]->hasItem(Item::get('MapD3', $this->world)));
         })->setFillRules(function ($item, $locations, $items) {
             if (
                 !$this->world->config('region.bossNormalLocation', true)
@@ -149,7 +151,7 @@ class SkullWoods extends Region
                 && ($this->world->config('itemPlacement') !== 'basic'
                     || (($this->world->config('mode.weapons') === 'swordless' || $items->hasSword()) && $items->hasHealth(7) && $items->hasABottle()))
                 && ($this->world->config('canDungeonRevive', false) || $items->has('MoonPearl')
-                    || (($items->hasABottle() && $this->world->config('canOWYBA', false))
+                    || (($this->world->config('canOWYBA', false) && $items->hasABottle())
                         || ($this->world->config('canBunnyRevive', false) && $items->canBunnyRevive())))
                 && $this->world->getRegion('North West Dark World')->canEnter($locations, $items);
         };

--- a/app/Region/Standard/SwampPalace.php
+++ b/app/Region/Standard/SwampPalace.php
@@ -74,10 +74,9 @@ class SwampPalace extends Region
         $mire = function ($locations, $items) {
             return $this->world->config('canOneFrameClipUW', false)
                 && (($locations->itemInLocations(Item::get('BigKeyD6', $this->world), [
-                        "Misery Mire - Compass Chest",
-                        "Misery Mire - Big Key Chest",
-                    ])
-                    && $items->has('KeyD6', 2))
+                    "Misery Mire - Compass Chest",
+                    "Misery Mire - Big Key Chest",
+                ]) && $items->has('KeyD6', 2))
                     || $items->has('KeyD6', 3))
                 && $this->world->getRegion('Misery Mire')->canEnter($locations, $items);
         };
@@ -158,8 +157,10 @@ class SwampPalace extends Region
                 && ($items->has('Hammer') 
                     || $mire($locations, $items) || $hera($locations, $items))
                 && $this->boss->canBeat($items, $locations)
-                && (!$this->world->config('region.wildCompasses', false) || $items->has('CompassD2') || $this->locations["Swamp Palace - Boss"]->hasItem(Item::get('CompassD2', $this->world)))
-                && (!$this->world->config('region.wildMaps', false) || $items->has('MapD2') || $this->locations["Swamp Palace - Boss"]->hasItem(Item::get('MapD2', $this->world)));
+                && (!$this->world->config('region.wildCompasses', false) || $items->has('CompassD2')
+                    || $this->locations["Swamp Palace - Boss"]->hasItem(Item::get('CompassD2', $this->world)))
+                && (!$this->world->config('region.wildMaps', false) || $items->has('MapD2')
+                    || $this->locations["Swamp Palace - Boss"]->hasItem(Item::get('MapD2', $this->world)));
         })->setFillRules(function ($item, $locations, $items) {
             if (
                 !$this->world->config('region.bossNormalLocation', true)
@@ -188,8 +189,7 @@ class SwampPalace extends Region
                         && $locations["Old Man"]->canAccess($items)
                         && (($items->has('PegasusBoots')
                             && $this->world->config('canBootsClip', false))
-                            || ($this->world->config('canSuperSpeed', false)
-                                && $items->canSpinSpeed())
+                            || ($this->world->config('canSuperSpeed', false) && $items->canSpinSpeed())
                             || $this->world->config('canOneFrameClipOW', false))));
         };
 

--- a/app/Region/Standard/ThievesTown.php
+++ b/app/Region/Standard/ThievesTown.php
@@ -96,8 +96,10 @@ class ThievesTown extends Region
             return $this->canEnter($locations, $items)
                 && $items->has('KeyD4') && $items->has('BigKeyD4')
                 && $this->boss->canBeat($items, $locations)
-                && (!$this->world->config('region.wildCompasses', false) || $items->has('CompassD4') || $this->locations["Thieves' Town - Boss"]->hasItem(Item::get('CompassD4', $this->world)))
-                && (!$this->world->config('region.wildMaps', false) || $items->has('MapD4') || $this->locations["Thieves' Town - Boss"]->hasItem(Item::get('MapD4', $this->world)));
+                && (!$this->world->config('region.wildCompasses', false) || $items->has('CompassD4')
+                    || $this->locations["Thieves' Town - Boss"]->hasItem(Item::get('CompassD4', $this->world)))
+                && (!$this->world->config('region.wildMaps', false) || $items->has('MapD4')
+                    || $this->locations["Thieves' Town - Boss"]->hasItem(Item::get('MapD4', $this->world)));
         })->setFillRules(function ($item, $locations, $items) {
             if (
                 !$this->world->config('region.bossNormalLocation', true)
@@ -118,7 +120,7 @@ class ThievesTown extends Region
                 && ($this->world->config('itemPlacement') !== 'basic'
                     || (($this->world->config('mode.weapons') === 'swordless' || $items->hasSword()) && $items->hasHealth(7) && $items->hasABottle()))
                 && ($items->has('MoonPearl')
-                    || ($items->hasABottle() && $this->world->config('canOWYBA', false))
+                    || ($this->world->config('canOWYBA', false) && $items->hasABottle())
                     || ($this->world->config('canBunnyRevive', false) && $items->canSpinSpeed()))
                 && $this->world->getRegion('North West Dark World')->canEnter($locations, $items);
         };

--- a/app/Region/Standard/TowerOfHera.php
+++ b/app/Region/Standard/TowerOfHera.php
@@ -100,8 +100,8 @@ class TowerOfHera extends Region
     public function initalize()
     {
         $main = function ($locations, $items) {
-            return (($items->has('PegasusBoots') && $this->world->config('canBootsClip', false))
-                || ($this->world->config('canSuperSpeed', false) && $items->canSpinSpeed()))
+            return (($this->world->config('canBootsClip', false) && $items->has('PegasusBoots'))
+                    || ($this->world->config('canSuperSpeed', false) && $items->canSpinSpeed()))
                 || $this->world->config('canOneFrameClipOW', false)
                 || (($items->has('MagicMirror') || ($items->has('Hookshot') && $items->has('Hammer')))
                     && $this->world->getRegion('West Death Mountain')->canEnter($locations, $items));
@@ -141,8 +141,10 @@ class TowerOfHera extends Region
             return $main($locations, $items)
                 && $this->boss->canBeat($items, $locations)
                 && ($items->has('BigKeyP3') || ($mire($locations, $items) && $items->has('BigKeyD6')))
-                && (!$this->world->config('region.wildCompasses', false) || $items->has('CompassP3') || $this->locations["Tower of Hera - Boss"]->hasItem(Item::get('CompassP3', $this->world)))
-                && (!$this->world->config('region.wildMaps', false) || $items->has('MapP3') || $this->locations["Tower of Hera - Boss"]->hasItem(Item::get('MapP3', $this->world)));
+                && (!$this->world->config('region.wildCompasses', false) || $items->has('CompassP3')
+                    || $this->locations["Tower of Hera - Boss"]->hasItem(Item::get('CompassP3', $this->world)))
+                && (!$this->world->config('region.wildMaps', false) || $items->has('MapP3')
+                    || $this->locations["Tower of Hera - Boss"]->hasItem(Item::get('MapP3', $this->world)));
         })->setFillRules(function ($item, $locations, $items) {
             if (
                 !$this->world->config('region.bossNormalLocation', true)

--- a/app/Region/Standard/TurtleRock.php
+++ b/app/Region/Standard/TurtleRock.php
@@ -85,8 +85,8 @@ class TurtleRock extends Region
     {
         $upper = function ($locations, $items) {
             return (($locations["Turtle Rock Medallion"]->hasItem(Item::get('Bombos', $this->world)) && $items->has('Bombos'))
-                || ($locations["Turtle Rock Medallion"]->hasItem(Item::get('Ether', $this->world)) && $items->has('Ether'))
-                || ($locations["Turtle Rock Medallion"]->hasItem(Item::get('Quake', $this->world)) && $items->has('Quake')))
+                    || ($locations["Turtle Rock Medallion"]->hasItem(Item::get('Ether', $this->world)) && $items->has('Ether'))
+                    || ($locations["Turtle Rock Medallion"]->hasItem(Item::get('Quake', $this->world)) && $items->has('Quake')))
                 && ($this->world->config('mode.weapons') == 'swordless' || $items->hasSword())
                 && ($items->has('MoonPearl')
                     || ($this->world->config('canOWYBA', false) && $items->hasABottle()
@@ -188,32 +188,36 @@ class TurtleRock extends Region
 
         $this->locations["Turtle Rock - Eye Bridge - Bottom Left"]->setRequirements(function ($locations, $items) use ($upper, $middle, $lower) {
             return ($lower($locations, $items)
-                || (($upper($locations, $items) || $middle($locations, $items)) &&
-                    $items->has('Lamp', $this->world->config('item.require.Lamp', 1)) && $items->has('CaneOfSomaria') && $items->has('BigKeyD7') && $items->has('KeyD7', 3)))
+                || (($upper($locations, $items) || $middle($locations, $items))
+                    && $items->has('Lamp', $this->world->config('item.require.Lamp', 1)) && $items->has('CaneOfSomaria')
+                    && $items->has('BigKeyD7') && $items->has('KeyD7', 3)))
                 && ($this->world->config('itemPlacement') !== 'basic' || $items->has('Cape') || $items->has('CaneOfByrna')
                     || ($this->world->config('item.overflow.count.Shield', 3) >= 3 && $items->canBlockLasers()));
         });
 
         $this->locations["Turtle Rock - Eye Bridge - Bottom Right"]->setRequirements(function ($locations, $items) use ($upper, $middle, $lower) {
             return ($lower($locations, $items)
-                || (($upper($locations, $items) || $middle($locations, $items)) &&
-                    $items->has('Lamp', $this->world->config('item.require.Lamp', 1)) && $items->has('CaneOfSomaria') && $items->has('BigKeyD7') && $items->has('KeyD7', 3)))
+                || (($upper($locations, $items) || $middle($locations, $items))
+                    && $items->has('Lamp', $this->world->config('item.require.Lamp', 1)) && $items->has('CaneOfSomaria')
+                    && $items->has('BigKeyD7') && $items->has('KeyD7', 3)))
                 && ($this->world->config('itemPlacement') !== 'basic' || $items->has('Cape') || $items->has('CaneOfByrna')
                     || ($this->world->config('item.overflow.count.Shield', 3) >= 3 && $items->canBlockLasers()));
         });
 
         $this->locations["Turtle Rock - Eye Bridge - Top Left"]->setRequirements(function ($locations, $items) use ($upper, $middle, $lower) {
             return ($lower($locations, $items)
-                || (($upper($locations, $items) || $middle($locations, $items)) &&
-                    $items->has('Lamp', $this->world->config('item.require.Lamp', 1)) && $items->has('CaneOfSomaria') && $items->has('BigKeyD7') && $items->has('KeyD7', 3)))
+                || (($upper($locations, $items) || $middle($locations, $items))
+                    && $items->has('Lamp', $this->world->config('item.require.Lamp', 1)) && $items->has('CaneOfSomaria')
+                    && $items->has('BigKeyD7') && $items->has('KeyD7', 3)))
                 && ($this->world->config('itemPlacement') !== 'basic' || $items->has('Cape') || $items->has('CaneOfByrna')
                     || ($this->world->config('item.overflow.count.Shield', 3) >= 3 && $items->canBlockLasers()));
         });
 
         $this->locations["Turtle Rock - Eye Bridge - Top Right"]->setRequirements(function ($locations, $items) use ($upper, $middle, $lower) {
             return ($lower($locations, $items)
-                || (($upper($locations, $items) || $middle($locations, $items)) &&
-                    $items->has('Lamp', $this->world->config('item.require.Lamp', 1)) && $items->has('CaneOfSomaria') && $items->has('BigKeyD7') && $items->has('KeyD7', 3)))
+                || (($upper($locations, $items) || $middle($locations, $items))
+                    && $items->has('Lamp', $this->world->config('item.require.Lamp', 1)) && $items->has('CaneOfSomaria')
+                    && $items->has('BigKeyD7') && $items->has('KeyD7', 3)))
                 && ($this->world->config('itemPlacement') !== 'basic' || $items->has('Cape') || $items->has('CaneOfByrna')
                     || ($this->world->config('item.overflow.count.Shield', 3) >= 3 && $items->canBlockLasers()));
         });
@@ -235,8 +239,10 @@ class TurtleRock extends Region
                     || $items->has('Lamp', $this->world->config('item.require.Lamp', 1)))
                 && $items->has('BigKeyD7') && $items->has('CaneOfSomaria')
                 && $this->boss->canBeat($items, $locations)
-                && (!$this->world->config('region.wildCompasses', false) || $items->has('CompassD7') || $this->locations["Turtle Rock - Boss"]->hasItem(Item::get('CompassD7', $this->world)))
-                && (!$this->world->config('region.wildMaps', false) || $items->has('MapD7') || $this->locations["Turtle Rock - Boss"]->hasItem(Item::get('MapD7', $this->world)));
+                && (!$this->world->config('region.wildCompasses', false) || $items->has('CompassD7')
+                    || $this->locations["Turtle Rock - Boss"]->hasItem(Item::get('CompassD7', $this->world)))
+                && (!$this->world->config('region.wildMaps', false) || $items->has('MapD7')
+                    || $this->locations["Turtle Rock - Boss"]->hasItem(Item::get('MapD7', $this->world)));
         })->setFillRules(function ($item, $locations, $items) {
             if (
                 !$this->world->config('region.bossNormalLocation', true)
@@ -254,7 +260,8 @@ class TurtleRock extends Region
         $this->can_enter = function ($locations, $items) use ($lower, $middle, $upper) {
             return $items->has('RescueZelda')
                 && ($this->world->config('itemPlacement') !== 'basic'
-                    || (($this->world->config('mode.weapons') === 'swordless' || $items->hasSword(2)) && $items->hasHealth(12) && ($items->hasBottle(2) || $items->hasArmor())))
+                    || (($this->world->config('mode.weapons') === 'swordless' || $items->hasSword(2))
+                        && $items->hasHealth(12) && ($items->hasBottle(2) || $items->hasArmor())))
                 && ($lower($locations, $items)
                     || $middle($locations, $items)
                     || $upper($locations, $items));


### PR DESCRIPTION
- Wrap expressions by logic operator structure rather than an arbitrary fashion.
- Place config checks before item checks (e.g. canFakeFlipper before Flippers).
- Group the "be link" section for inverted "Bomb Hut" so that it pairs correctly with `canBombThings`.